### PR TITLE
Changed `sp-pair-overlay-face' to inherit from highlight face.

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -1038,7 +1038,7 @@ string and the action."
 
 ;; burlywood4
 (defface sp-pair-overlay-face
-  '((t (:background "#004a5d")))
+  '((t (:inherit highlight)))
   "The face used to highlight pair overlays."
   :group 'smartparens)
 


### PR DESCRIPTION
This provides a better "out of the box" experience. The previous face
was designed to 'be "pleasant" on the tango-dark color scheme'.

By using the highlight face it should be pleasant on any color scheme.
