### PR TITLE
Pair with spaces does not work (add failing scenarios)

### DIFF
--- a/features/insert-pair.feature
+++ b/features/insert-pair.feature
@@ -146,6 +146,12 @@ Feature: Autoinsert pairs
     And I type "\""
     Then I should see "[one or two \"words\"\" ]"
 
+  Scenario: Spaces in pair definition
+    Given I add a pair "! / !"
+      And I turn on smartparens
+     When I press "! SPC x"
+     Then I should see "! x !"
+
   Scenario: Add local pair
     Given I add a local pair "'/!" on "rst-mode"
     And I turn on rst-mode
@@ -260,3 +266,34 @@ Feature: Autoinsert pairs
     And I press "*"
     Then I should see "**"
 
+  Scenario: Set local actions to nil to free prefix
+    Given I add a local pair "[/]" on "sh-mode" with actions "nil"
+      And I add a local pair "[ / ]" on "sh-mode"
+      And I add a local pair "[!/!]" on "sh-mode"
+      And I add a local pair "[[/]]" on "sh-mode"
+      And I turn on sh-mode
+      And I turn on smartparens
+     When I type "[["
+     Then I should see "[[]]"
+     When the buffer is empty
+      And I press "[!"
+     Then I should see "[!!]"
+     When the buffer is empty
+      And I press "[ SPC"
+     Then I should see "[  ]"
+
+  Scenario: Remove local actions to free prefix
+    Given I add a local pair "[/]" on "sh-mode" with actions "(:rem wrap insert)"
+      And I add a local pair "[ / ]" on "sh-mode"
+      And I add a local pair "[!/!]" on "sh-mode"
+      And I add a local pair "[[/]]" on "sh-mode"
+      And I turn on sh-mode
+      And I turn on smartparens
+     When I type "[["
+     Then I should see "[[]]"
+     When the buffer is empty
+      And I press "[!"
+     Then I should see "[!!]"
+     When the buffer is empty
+      And I press "[ SPC"
+     Then I should see "[  ]"

--- a/features/step-definitions/smartparens-steps.el
+++ b/features/step-definitions/smartparens-steps.el
@@ -28,6 +28,11 @@
        (lambda ()
          (smartparens-mode -1)))
 
+(Given "^I add a pair \"\\([^\"]+\\)\"$"
+       (lambda (pair)
+         (let ((args (split-string pair "/")))
+           (apply #'sp-pair args))))
+
 (Given "^I add a local pair \"\\([^\"]+\\)\" on \"\\([^\"]+\\)\" ?\\(.*\\)$"
        (lambda (pair modes-1 modifier)
          (let ((args (split-string pair "/"))
@@ -40,5 +45,8 @@
 	    ((equal "disabled only in string" modifier)
 	     (setq args (append args '(:unless (sp-in-string-p)))))
 	    ((equal "disabled only in code" modifier)
-	     (setq args (append args '(:unless (sp-in-code-p))))))
+	     (setq args (append args '(:unless (sp-in-code-p)))))
+            ((string-match "with actions \"\\([^\"]+\\)\"" modifier)
+             (setq args (append args `(:actions
+                                       ,(read (match-string 1 modifier)))))))
            (apply #'sp-local-pair modes args))))


### PR DESCRIPTION
I tried the following setup but didn't work.

``` cl
(sp-with-modes 'sh-mode
  (sp-local-pair "[" "]" :actions nil)  ; I also tried '(:rem wrap insert)
  (sp-local-pair "[ " " ]")
  (sp-local-pair "[[" "]]"))
```

To replicate the problem, I wrote two failing scenarios.  I thought the problem was removing pairs but there was another problem with pair with whitespaces.

In case this takes sometime to fix, I propose to add `@known` tag so that you can keep travis result clean (e2f11e395860f6d51cadbfd1f0bbb0953195afa1).
