### PR TITLE
Scenario for minibuffer and read-passwd

### DIFF
--- a/features/insert-pair.feature
+++ b/features/insert-pair.feature
@@ -311,3 +311,8 @@ Feature: Autoinsert pairs
       And I execute the action chain
       And I press "C-y"
      Then I should see "()"
+
+  Scenario: Insert characters in read-passwd prompt
+    Given I set sp-ignore-modes-list to nil
+      And I turn on smartparens globally
+     Then typing "my password" on password prompt works

--- a/features/step-definitions/smartparens-steps.el
+++ b/features/step-definitions/smartparens-steps.el
@@ -50,3 +50,15 @@
              (setq args (append args `(:actions
                                        ,(read (match-string 1 modifier)))))))
            (apply #'sp-local-pair modes args))))
+
+(Then "^typing \"\\([^\"]+\\)\" on password prompt works$"
+  "Check that `read-passwd' based password prompt works."
+  (lambda (type)
+    (let (result)
+      (execute-kbd-macro
+       (vconcat (edmacro-parse-keys "M-:")
+                (string-to-vector "(setq result (read-passwd \"> \"))")
+                (edmacro-parse-keys "RET")
+                (string-to-vector type)))
+      (assert (equal result type) nil
+              "Typed %S but got %S" type result))))


### PR DESCRIPTION
The scenario for read-passwd fails (it actually hangs the test).
