### PR TITLE
[Issue #64] Fix the minibuffer bug on 24.3.xy emacs builds

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -1412,7 +1412,7 @@ would execute if smartparens-mode were disabled."
   "Call the command bound to last key sequence as if SP were disabled."
   (let ((com (sp--keybinding-fallback))
         (smartparens-mode nil))
-    (when com
+    (when (and com (commandp com))
       (setq this-original-command com)
       (call-interactively com))))
 


### PR DESCRIPTION
Just to run tests on travis with 24.3.xy
