### PR TITLE
[ruby-mode] Avoid inserting end tag for if and do in the middle of a word.

### DIFF
--- a/smartparens-ruby.el
+++ b/smartparens-ruby.el
@@ -91,17 +91,27 @@
       (delete-indentation -1))
     (newline)))
 
+(defun sp-ruby-in-string-or-word-p (id action context)
+  (or (sp-in-string-p id action context)
+      (and (looking-back id)
+           (not (looking-back (sp--strict-regexp-quote id))))))
+
+(defun sp-ruby-no-do-block-p (id action context)
+  (or (sp-ruby-in-string-or-symbol-p id action context)
+      (and (looking-back (sp--strict-regexp-quote id))
+           (not (looking-back (concat "[^ ] " id))))))
+
 (sp-with-modes '(ruby-mode)
 
   ;; Blocks
   (sp-local-pair "do" "end"
-                 :unless '(sp-in-string-p)
+                 :unless '(sp-ruby-no-do-block-p)
                  :actions '(insert)
                  :pre-handlers '(sp-ruby-pre-handler)
                  :post-handlers '(sp-ruby-block-post-handler))
 
   (sp-local-pair "begin" "end"
-                 :unless '(sp-in-string-p)
+                 :unless '(sp-ruby-in-string-or-word-p)
                  :actions '(insert)
                  :pre-handlers '(sp-ruby-pre-handler)
                  :post-handlers '(sp-ruby-block-post-handler))
@@ -109,31 +119,31 @@
   ;; Defs
 
   (sp-local-pair "def" "end"
-                 :unless '(sp-in-string-p)
+                 :unless '(sp-ruby-in-string-or-word-p)
                  :actions '(insert)
                  :pre-handlers '(sp-ruby-pre-handler)
                  :post-handlers '(sp-ruby-def-post-handler))
 
   (sp-local-pair "class" "end"
-                 :unless '(sp-in-string-p)
+                 :unless '(sp-ruby-in-string-or-word-p)
                  :actions '(insert)
                  :pre-handlers '(sp-ruby-pre-handler)
                  :post-handlers '(sp-ruby-def-post-handler))
 
   (sp-local-pair "module" "end"
-                 :unless '(sp-in-string-p)
+                 :unless '(sp-ruby-in-string-or-word-p)
                  :actions '(insert)
                  :pre-handlers '(sp-ruby-pre-handler)
                  :post-handlers '(sp-ruby-def-post-handler))
 
   (sp-local-pair "if" "end"
-                 :unless '(sp-in-string-p)
+                 :unless '(sp-ruby-in-string-or-word-p)
                  :actions '(insert)
                  :pre-handlers '(sp-ruby-pre-handler)
                  :post-handlers '(sp-ruby-def-post-handler))
 
   (sp-local-pair "unless" "end"
-                 :unless '(sp-in-string-p)
+                 :unless '(sp-ruby-in-string-or-word-p)
                  :actions '(insert)
                  :pre-handlers '(sp-ruby-pre-handler)
                  :post-handlers '(sp-ruby-def-post-handler))


### PR DESCRIPTION
This fixes problems when an insertion is triggered by `ver[if]ication`
and `[do]wnload`. Here is a list of examples:

Before:

``` ruby
verif|
end

bado|
end

do|
end

test do|
end

if|
end
```

After:

``` ruby
verif|

bado|

do|

test do|
end

if|
end
```
