### PR TITLE
Add Travis build status to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/Fuco1/smartparens.png?branch=master)](https://travis-ci.org/Fuco1/smartparens)
+
 # News
 
 #### Experimental support for pairs with same opening and closing delimiter


### PR DESCRIPTION
The build status of a project is always important, so we might very well show it to everyone in the README.
