### PR TITLE
Use cl-lib instead of cl

### DIFF
--- a/features/step-definitions/smartparens-steps.el
+++ b/features/step-definitions/smartparens-steps.el
@@ -4,17 +4,17 @@
 
 (When "^I exchange point and mark$"
       (lambda ()
-	(exchange-point-and-mark)))
+        (exchange-point-and-mark)))
 
 (Then "^last operation should be \"\\([^\"]+\\)\"$"
       (lambda (value)
-	(let ((message "sp-last-action should be %s, but is %s")
-	      (last-op (symbol-name sp-last-operation)))
-	  (assert (equal last-op value) nil message value last-op))))
+        (let ((message "sp-last-action should be %s, but is %s")
+              (last-op (symbol-name sp-last-operation)))
+          (cl-assert (equal last-op value) nil message value last-op))))
 
 (Then "^last wrapped region should be non-nil$"
       (lambda ()
-	(assert (not (null sp-last-wrapped-region)) nil "sp-last-wrapped-region should be non-nil, but is nil")))
+        (cl-assert (not (null sp-last-wrapped-region)) nil "sp-last-wrapped-region should be non-nil, but is nil")))
 
 (Given "^I turn on smartparens globally$"
        (lambda ()
@@ -40,26 +40,26 @@
            (cond
             ((equal "enabled only in string" modifier)
              (setq args (append args '(:when (sp-in-string-p)))))
-	    ((equal "enabled only in code" modifier)
-	     (setq args (append args '(:when (sp-in-code-p)))))
-	    ((equal "disabled only in string" modifier)
-	     (setq args (append args '(:unless (sp-in-string-p)))))
-	    ((equal "disabled only in code" modifier)
-	     (setq args (append args '(:unless (sp-in-code-p)))))
+            ((equal "enabled only in code" modifier)
+             (setq args (append args '(:when (sp-in-code-p)))))
+            ((equal "disabled only in string" modifier)
+             (setq args (append args '(:unless (sp-in-string-p)))))
+            ((equal "disabled only in code" modifier)
+             (setq args (append args '(:unless (sp-in-code-p)))))
             ((string-match "with actions \"\\([^\"]+\\)\"" modifier)
              (setq args (append args `(:actions
                                        ,(read (match-string 1 modifier)))))))
            (apply #'sp-local-pair modes args))))
 
 (Then "^typing \"\\([^\"]+\\)\" on password prompt works$"
-  "Check that `read-passwd' based password prompt works."
-  (lambda (type)
-    (let (result)
-      (execute-kbd-macro
-       (vconcat (edmacro-parse-keys "M-:")
-                (string-to-vector "(setq result (read-passwd \"> \"))")
-                (edmacro-parse-keys "RET")
-                (string-to-vector type)
-                (edmacro-parse-keys "RET")))
-      (assert (equal result type) nil
-              "Typed %S but got %S" type result))))
+      "Check that `read-passwd' based password prompt works."
+      (lambda (type)
+        (let (result)
+          (execute-kbd-macro
+           (vconcat (edmacro-parse-keys "M-:")
+                    (string-to-vector "(setq result (read-passwd \"> \"))")
+                    (edmacro-parse-keys "RET")
+                    (string-to-vector type)
+                    (edmacro-parse-keys "RET")))
+          (cl-assert (equal result type) nil
+                     "Typed %S but got %S" type result))))

--- a/smartparens-pkg.el
+++ b/smartparens-pkg.el
@@ -2,4 +2,4 @@
   "smartparens"
   "1.4.4"
   "Automatic insertion, wrapping and paredit-like navigation with user defined pairs."
-  '((dash "1.1.0")))
+  '((cl-lib "0.1") (dash "1.1.0")))


### PR DESCRIPTION
The `cl` library was finally deprecated in Emacs 24.3. `cl-lib` provides
namespace-clean versions of the functions and macros from `cl`.

The `cl-lib` package from ELPA is used to provide a version of `cl-lib`
for older Emacsen.
