### PR TITLE
Don't add deleted pair to kill ring

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -2929,9 +2929,9 @@ is remove the just added wrapping."
             (setq sp-last-operation 'sp-delete-pair-opening))))
          ;; we're inside a pair
          ((and inside-pair sp-autodelete-pair)
-          (zap-to-char 1 (string-to-char (cdr inside-pair)))
+          (search-forward (substring (cdr inside-pair) 0 1))
+          (delete-char (- (+ (- (point) p) (1- (length (car inside-pair))))))
           (delete-char (1- (length (cdr inside-pair))))
-          (delete-char (- (1- (length (car inside-pair)))))
           (setq sp-last-operation 'sp-delete-pair))
          ;; we're behind a closing pair
          ((and behind-pair sp-autodelete-closing-pair)


### PR DESCRIPTION
In `sp-delete-pair` function, replace `zap-to-char` functionality because it will add to kill ring a part of deleted pair.
