### PR TITLE
Add missing Carton dependency

### DIFF
--- a/Carton
+++ b/Carton
@@ -3,6 +3,7 @@
 (package "smartparens" "0"
          "Autoinsert pairs of defined brackets and wrap regions")
 
+(depends-on "cl-lib")
 (depends-on "dash")
 
 (development


### PR DESCRIPTION
I had forgotten to update Carton's config file when I introduced `cl-lib`.
