### PR TITLE
[ruby-mode] Add a local pair for until

### DIFF
--- a/smartparens-ruby.el
+++ b/smartparens-ruby.el
@@ -243,6 +243,14 @@
                  :post-handlers '(sp-ruby-def-post-handler)
                  :skip-match 'sp-ruby-skip-inline-match-p)
 
+  (sp-local-pair "until" "end"
+                 :when '(("SPC" "RET" "<evil-ret>"))
+                 :unless '(sp-ruby-in-string-word-or-inline-p)
+                 :actions '(insert)
+                 :pre-handlers '(sp-ruby-pre-handler)
+                 :post-handlers '(sp-ruby-def-post-handler)
+                 :skip-match 'sp-ruby-skip-inline-match-p)
+
   (sp-local-pair "|" "|"
                  :when '(sp-ruby-should-insert-pipe-close)
                  :actions '(insert)


### PR DESCRIPTION
`until` was missing in `smartparens-ruby`, so I added it.
