### PR TITLE
[ruby-mode] Add local pair for `for`

### DIFF
--- a/smartparens-ruby.el
+++ b/smartparens-ruby.el
@@ -256,6 +256,14 @@
                  :post-handlers '(sp-ruby-def-post-handler)
                  :skip-match 'sp-ruby-skip-inline-match-p)
 
+  (sp-local-pair "for" "end"
+                 :when '(("SPC" "RET" "<evil-ret>"))
+                 :unless '(sp-ruby-in-string-word-or-inline-p)
+                 :actions '(insert)
+                 :pre-handlers '(sp-ruby-pre-handler)
+                 :post-handlers '(sp-ruby-def-post-handler)
+                 :skip-match 'sp-ruby-skip-inline-match-p)
+
   (sp-local-pair "|" "|"
                  :when '(sp-ruby-should-insert-pipe-close)
                  :actions '(insert)


### PR DESCRIPTION
This adds support for:

``` ruby
for x in 1..10
  puts x
end
```

While people should normally avoid `for`, we should definitely handle it properly in smartparens.
