### PR TITLE
Fix byte-compilation error

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -5056,8 +5056,8 @@ triggers that `sp-forward-slurp-sexp' does."
         ;; we need to call this again to get the new structure after
         ;; indent.
         (sp--next-thing-selection -1))
-    (message "This operation would result in invalid structure. Ignored.")
-    nil))
+    (message "This operation would result in invalid structure. Ignored."))
+  nil)
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
The specific error:

```
smartparens.el:5009:1:Error: Wrong number of arguments: (lambda (vars-vals then &optional else) "If all VALS evaluate to true, bind them to their corresponding
VARS and do THEN, otherwise do ELSE. VARS-VALS should be a list
of (VAR VAL) pairs (corresponding to the bindings of `let*')." (let ((first-pair (car vars-vals)) (rest (cdr vars-vals))) (if (= (length vars-vals) 1) (list (quote -if-let) first-pair then else) (list (quote -if-let) first-pair (list (quote -if-let*) rest then else) else)))), 4
```

Also, there might have been a minor bug in that before this patch, in that I think Smartparens would _always_ execute `(message "This operation would…` after running `sp-slurp-hybrid-sexp`.
