### PR TITLE
add jinja2-mode to sp--html-modes

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -422,6 +422,7 @@ Symbol is defined as a chunk of text recognized by
                          nxhtml-mode
                          nxml-mode
                          web-mode
+                         jinja2-mode
                          )
   "List of HTML modes.")
 


### PR DESCRIPTION
Sometime I use jinja2-mode, a mode for flask's template. When I use this, it told me that couldn't load smartparens-html. So I added it. Or I can just (add-to-list 'sp--html-modes 'jinja2-mode)?
