### PR TITLE
Add test that should fail, but does not.

### DIFF
--- a/features/show.feature
+++ b/features/show.feature
@@ -1,0 +1,12 @@
+Feature: Show
+
+  Scenario: Emacs Lisp hang bug
+    Given I insert:
+      """
+      (add-to-list 'auto-mode-alist '("\\.html?\\'" . html-mode))
+      """
+    And I turn on emacs-lisp-mode
+    And I turn on smartparens
+    And I turn on show smartparens
+    When I go to point "45"
+    And I press "C-b"

--- a/features/step-definitions/smartparens-steps.el
+++ b/features/step-definitions/smartparens-steps.el
@@ -28,6 +28,10 @@
   (lambda ()
     (smartparens-mode -1)))
 
+(Given "^I turn on show smartparens$"
+  (lambda ()
+    (show-smartparens-mode 1)))
+
 (Given "^I add a pair \"\\([^\"]+\\)\"$"
   (lambda (pair)
     (let ((args (split-string pair "/")))


### PR DESCRIPTION
Hi,

For some reason I cannot reproduce the error using Ecukes. Maybe because something in `env.el` changes the default behavior.

Anyway, if you open a clean Emacs and try the steps below, Emacs will hang.
