### PR TITLE
smartparens-ruby: Do not insert match when in comment

### DIFF
--- a/smartparens-ruby.el
+++ b/smartparens-ruby.el
@@ -257,7 +257,7 @@
 (sp-with-modes '(ruby-mode enh-ruby-mode)
   (sp-local-pair "do" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-ruby-in-string-or-word-p)
+                 :unless '(sp-ruby-in-string-or-word-p sp-in-comment-p)
                  :actions '(insert)
                  :pre-handlers '(sp-ruby-pre-handler)
                  :post-handlers '(sp-ruby-block-post-handler)
@@ -271,7 +271,7 @@
 
   (sp-local-pair "begin" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-ruby-in-string-or-word-p)
+                 :unless '(sp-ruby-in-string-or-word-p sp-in-comment-p)
                  :actions '(insert)
                  :pre-handlers '(sp-ruby-pre-handler)
                  :post-handlers '(sp-ruby-block-post-handler)
@@ -280,7 +280,7 @@
 
   (sp-local-pair "def" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-ruby-in-string-or-word-p)
+                 :unless '(sp-ruby-in-string-or-word-p sp-in-comment-p)
                  :actions '(insert)
                  :pre-handlers '(sp-ruby-pre-handler)
                  :post-handlers '(sp-ruby-def-post-handler)
@@ -289,7 +289,7 @@
 
   (sp-local-pair "class" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-ruby-in-string-or-word-p)
+                 :unless '(sp-ruby-in-string-or-word-p sp-in-comment-p)
                  :actions '(insert)
                  :pre-handlers '(sp-ruby-pre-handler)
                  :post-handlers '(sp-ruby-def-post-handler)
@@ -298,7 +298,7 @@
 
   (sp-local-pair "module" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-ruby-in-string-or-word-p)
+                 :unless '(sp-ruby-in-string-or-word-p sp-in-comment-p)
                  :actions '(insert)
                  :pre-handlers '(sp-ruby-pre-handler)
                  :post-handlers '(sp-ruby-def-post-handler)
@@ -307,7 +307,7 @@
 
   (sp-local-pair "case" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-ruby-in-string-or-word-p)
+                 :unless '(sp-ruby-in-string-or-word-p sp-in-comment-p)
                  :actions '(insert)
                  :pre-handlers '(sp-ruby-pre-handler)
                  :post-handlers '(sp-ruby-def-post-handler)
@@ -316,7 +316,7 @@
 
   (sp-local-pair "for" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-ruby-in-string-or-word-p)
+                 :unless '(sp-ruby-in-string-or-word-p sp-in-comment-p)
                  :actions '(insert)
                  :pre-handlers '(sp-ruby-pre-handler)
                  :post-handlers '(sp-ruby-def-post-handler)
@@ -324,7 +324,7 @@
 
   (sp-local-pair "if" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-ruby-in-string-word-or-inline-p)
+                 :unless '(sp-ruby-in-string-word-or-inline-p sp-in-comment-p)
                  :actions '(insert)
                  :pre-handlers '(sp-ruby-pre-handler)
                  :post-handlers '(sp-ruby-def-post-handler)
@@ -333,7 +333,7 @@
 
   (sp-local-pair "unless" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-ruby-in-string-word-or-inline-p)
+                 :unless '(sp-ruby-in-string-word-or-inline-p sp-in-comment-p)
                  :actions '(insert)
                  :pre-handlers '(sp-ruby-pre-handler)
                  :post-handlers '(sp-ruby-def-post-handler)
@@ -342,7 +342,7 @@
 
   (sp-local-pair "while" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-ruby-in-string-word-or-inline-p)
+                 :unless '(sp-ruby-in-string-word-or-inline-p sp-in-comment-p)
                  :actions '(insert)
                  :pre-handlers '(sp-ruby-pre-handler)
                  :post-handlers '(sp-ruby-def-post-handler)
@@ -351,7 +351,7 @@
 
   (sp-local-pair "until" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-ruby-in-string-word-or-inline-p)
+                 :unless '(sp-ruby-in-string-word-or-inline-p sp-in-comment-p)
                  :actions '(insert)
                  :pre-handlers '(sp-ruby-pre-handler)
                  :post-handlers '(sp-ruby-def-post-handler)


### PR DESCRIPTION
[A previous issue that I opened](https://github.com/Fuco1/smartparens/issues/264) relating to detecting if the point was within a string led to [this bug-fix commit](https://github.com/Fuco1/smartparens/commit/9d3b45ad3f0c6a900294de5447b920b551bf5ae8) that corrected a bug of comments being treated as strings by Smartparens.  However, that led to exposing a previous bug in the code.  If I am in a comment, I do not want writing the word "for", "do", or other Ruby keywords to create a pair match.  However, they get matched anyway.  When comments were detected as strings, this behavior was unintentionally suppressed, but it has arisen by the bug fix.  This pull request solves that problem by adding `sp-in-comment-p` to the list of unless functions for each pair that had either `sp-ruby-in-string-or-word-p` or `sp-ruby-in-string-word-or-inline-p` in its unless functions list.

This check is not necessary for pairs that have `sp-ruby-in-string-word-or-inline-p` in their list of unless functions, because `#`, which almost all Ruby comments in existence begin their lines with, is seen by `sp-ruby-in-string-word-or-inline-p` and causes the point to be deemed inline.  Although [there are ways to do block comments in Ruby](http://stackoverflow.com/questions/2989762/how-can-i-comment-multiple-lines-in-ruby), and they do not include `#` at the beginning of their lines, so maybe it is worth checking if the point is within a comment.  If you want me to remove checking if the point is within a comment when the function `sp-ruby-in-string-word-or-inline-p` is in the list of unless functions, let me know.
