### PR TITLE
Add *~* pattern to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 elpa
 *.elc
+*~*
 hybridline.el
 loading.el
 presentation2.org


### PR DESCRIPTION
Hi Matus,

I've add *~* pattern to .gitignore since ".~" is the default backup directory it
is better to ignore it as well.
