### PR TITLE
Respect LaTeX Foreign Characters

### DIFF
--- a/smartparens-latex.el
+++ b/smartparens-latex.el
@@ -73,7 +73,8 @@
   "Return t if point follows a backslash, nil otherwise.
 This predicate is only tested on \"insert\" action."
   (when (eq action 'insert)
-    (looking-back (concat "\\\\" (regexp-quote (if (sp-get-pair id :trigger) (sp-get-pair id :trigger) id))))))
+    (let ((trigger (sp-get-pair id :trigger)))
+      (looking-back (concat "\\\\" (regexp-quote (if trigger trigger id)))))))
 
 (add-to-list 'sp-navigate-skip-match
              '((tex-mode plain-tex-mode latex-mode) . sp--backslash-skip-match))


### PR DESCRIPTION
In the LaTeX commands [here](http://en.wikibooks.org/wiki/LaTeX/Special_Characters#Escaped_codes), `\"` and `\`` are used.  Currently, Smartparens will match `"` and ``` in these circumstances (the previous character is a backslash).  I would have a pull request, but I committed https://github.com/Sammidysam/smartparens/commit/29e955741a51d13774ee37154235e28bcd6878d6 on my fork and it did not work.  Functionality should be added so that pressing `"` will come out as `"` when a backslash is the previous character and ``` ``` in the same circumstance.
