### PR TITLE
First attempt at fixing bug #289

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -1339,7 +1339,8 @@ beginning."
   (memq this-original-command '(self-insert-command
                                 org-self-insert-command
                                 orgtbl-self-insert-command
-                                sp--self-insert-command)))
+                                ;;sp--self-insert-command
+                                )))
 
 (defun sp--signum (x)
   "Return 1 if X is positive, -1 if negative, 0 if zero."

--- a/smartparens.el
+++ b/smartparens.el
@@ -30,11 +30,11 @@
 ;;; Commentary:
 
 ;; Smartparens is minor mode for Emacs that deals with parens pairs
-;; and tries to be smart about it. It started as a unification effort
+;; and tries to be smart about it.  It started as a unification effort
 ;; to combine functionality of several existing packages in a single,
 ;; compatible and extensible way to deal with parentheses, delimiters,
-;; tags and the like. Some of these packages include autopair,
-;; textmate, wrap-region, electric-pair-mode, paredit and others. With
+;; tags and the like.  Some of these packages include autopair,
+;; textmate, wrap-region, electric-pair-mode, paredit and others.  With
 ;; the basic features found in other packages it also brings many
 ;; improvements as well as completely new features.
 
@@ -424,6 +424,7 @@ Symbol is defined as a chunk of text recognized by
                          inferior-emacs-lisp-mode
                          lisp-interaction-mode
                          scheme-mode
+                         scheme-interaction-mode
                          inferior-scheme-mode
                          geiser-repl-mode
                          lisp-mode
@@ -443,8 +444,50 @@ Symbol is defined as a chunk of text recognized by
                          nxml-mode
                          web-mode
                          jinja2-mode
+                         html-erb-mode
                          )
   "List of HTML modes.")
+
+(defvar sp-message-alist
+      '((:unmatched-expression
+         "Search failed. This means there is unmatched expression somewhere or we are at the beginning/end of file."
+         "Unmatched expression.")
+        (:delimiter-in-string
+         "Opening or closing pair is inside a string or comment and matching pair is outside (or vice versa). Ignored.")
+        (:no-matching-tag
+         "Search failed. No matching tag found."
+         "No matching tag.")
+        (:invalid-context-prev
+         "Invalid context: previous h-sexp ends after the next one."
+         "Invalid context.")
+        (:invalid-context-cur
+         "Invalid context: current h-sexp starts after the next one."
+         "Invalid context.")
+        (:no-structure-found
+         "Previous sexp starts after current h-sexp or no structure was found."
+         "No valid structure found.")
+        (:invalid-structure
+         "This operation would result in invalid structure. Ignored."
+         "Ignored because of invalid structure.")
+        (:cant-slurp
+         "We can't slurp without breaking strictly balanced expression. Ignored."
+         "Can't slurp without breaking balance.")
+        (:blank-sexp
+         "Point is in blank sexp, nothing to barf."
+         "Point is in blank sexp.")
+        (:point-not-deep-enough
+         "Point has to be at least two levels deep to swap the enclosing delimiters."
+         "Point has to be at least two levels deep."
+         "Point not deep enough.")
+        (:different-type
+         "The expressions to be joined are of different type."
+         "Expressions are of different type."))
+      "List of predefined messages to be displayed by `sp-message'.
+
+Each element is a list consisting of a keyword and one or more
+strings, which are chosen based on the `sp-message-width'
+variable. If the latter is `t', the first string is chosen as
+default, which should be the most verbose option available.")
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -479,6 +522,7 @@ You can enable pre-set bindings by customizing
 (defvar smartparens-strict-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map [remap delete-char] 'sp-delete-char)
+    (define-key map [remap delete-forward-char] 'sp-delete-char)
     (define-key map [remap backward-delete-char-untabify] 'sp-backward-delete-char)
     (define-key map [remap backward-delete-char] 'sp-backward-delete-char)
     (define-key map [remap delete-backward-char] 'sp-backward-delete-char)
@@ -514,7 +558,9 @@ after the smartparens indicator in the mode list."
         (setq sp-autoskip-closing-pair 'always))
     (setq minor-mode-overriding-map-alist
           (-remove (lambda (it) (eq (car it) 'smartparens-strict-mode)) minor-mode-overriding-map-alist))
-    (setq sp-autoskip-closing-pair (car (plist-get (symbol-plist 'sp-autoskip-closing-pair) 'standard-value)))))
+    (let ((std-val (car (plist-get (symbol-plist 'sp-autoskip-closing-pair) 'standard-value)))
+          (saved-val (car (plist-get (symbol-plist 'sp-autoskip-closing-pair) 'saved-value))))
+      (setq sp-autoskip-closing-pair (eval (or saved-val std-val))))))
 
 ;;;###autoload
 (define-globalized-minor-mode smartparens-global-strict-mode
@@ -942,7 +988,11 @@ setting affect all the navigation and manipulation functions
 where it make sense.
 
 Also, special handling of strings is enabled, where the whole
-string delimited with \"\" is considered as one token."
+string delimited with \"\" is considered as one token.
+
+WARNING: This is a legacy setting and changing its value to NIL
+may break many things.  It is kept only for backward
+compatibility and will be removed in the next major release."
   :type 'boolean
   :group 'smartparens)
 
@@ -1017,7 +1067,10 @@ expression.
 
 If the second argument is 'syntax, the third argument is
 interpreted as string containing syntax codes that will be
-skipped."
+skipped.
+
+You can also override this property locally for a specific pair
+by specifying its :prefix property."
   :type '(repeat
           (list symbol
                 (choice
@@ -1075,6 +1128,17 @@ The value of `comment-start' is used if the major mode is not found."
 (defcustom sp-highlight-wrap-tag-overlay t
   "If non-nil, wrap tag overlays are highlighted during editing of the wrapping tag pair."
   :type 'boolean
+  :group 'smartparens)
+
+(defcustom sp-message-width 'frame
+  "Length of information and error messages to display. If set to
+'frame (the default), messages are chosen based of the frame
+width. `t' means chose the default (verbose) message, `nil' means
+mute. Integers specify the maximum width."
+  :type '(choice (const :tag "Fit to frame" frame)
+                 (const :tag "Verbose" t)
+                 (const :tag "Mute" nil)
+                 (integer :tag "Max width"))
   :group 'smartparens)
 
 
@@ -1251,7 +1315,7 @@ beginning."
 
 (defun sp--back-to-indentation (old-column old-indentation)
   (let ((offset (sp--calculate-indentation-offset old-column old-indentation)))
-    (goto-char (+ (line-beginning-position) offset))))
+    (move-to-column offset)))
 
 (defmacro sp--keep-indentation (&rest body)
   "Execute BODY and restore the indentation."
@@ -1268,12 +1332,14 @@ beginning."
   "Return non-nil if `this-command' is some sort of `self-insert-command'."
   (memq this-command '(self-insert-command
                        org-self-insert-command
+                       orgtbl-self-insert-command
                        sp--self-insert-command)))
 
 (defun sp--this-original-command-self-insert-p ()
   "Return non-nil if `this-original-command' is some sort of `self-insert-command'."
   (memq this-original-command '(self-insert-command
                                 org-self-insert-command
+                                orgtbl-self-insert-command
                                 sp--self-insert-command)))
 
 (defun sp--signum (x)
@@ -1461,6 +1527,28 @@ which to do the comparsion."
   (setq what-a (or what-a :beg))
   (setq what-b (or what-b what-a))
   `(,fun (sp-get ,a ,what-a) (sp-get ,b ,what-b)))
+
+(defun sp-message (key)
+  "Display a message. The argument is either a string or list of
+strings, or a keyword, in which case the string list is looked up
+in `sp-message-alist'. The string to be displayed is chosen based
+on the `sp-message-width' variable."
+  (let ((msgs (cond ((listp key) key)
+                    ((stringp key) (list key))
+                    (t (cdr (assq key sp-message-alist))))))
+    (when (and msgs sp-message-width)
+      (if (eq sp-message-width t)
+          (message (car msgs))
+        (let ((maxlen (if (eq sp-message-width 'frame)
+                          (frame-width)
+                        sp-message-width))
+              (s nil))
+          (dolist (msg msgs)
+            (if (and (<= (length msg) maxlen)
+                     (> (length msg) (length s)))
+                (setf s msg)))
+          (when s
+            (message s)))))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1686,7 +1774,8 @@ this pair.  Possible values are:
 - autoskip - if the sexp is active or `sp-autoskip-closing-pair' is
   set to 'always, skip over the closing delimiter if user types its
   characters in order.
-- navigate - enable this pair for navigation/highlight.
+- navigate - enable this pair for navigation/highlight and strictness
+  checks
 
 If the ACTIONS argument has value :rem, the pair is removed.
 This can be used to remove default pairs you don't want to use.
@@ -2475,7 +2564,7 @@ see `sp-pair' for description."
 If the just-typed key is a possible trigger for any pair,
 `self-insert-command' is called and the special behaviours are
 handled in its advice provided by `smartparens-mode'.  If the
-just-typed key is not a trigger, fall back to the commant that
+just-typed key is not a trigger, fall back to the command that
 would execute if smartparens-mode were disabled."
   (interactive "p")
   (if (and (member (sp--single-key-description last-command-event) sp-trigger-keys)
@@ -2521,12 +2610,11 @@ would execute if smartparens-mode were disabled."
               ;; That is a function that would normally run if SP was
               ;; inactive. TODO: should this be customizable?
               (when (not action)
-                (let ((fb-fun (sp--keybinding-fallback)))
-                  (when (and (not (eq fb-fun 'self-insert-command))
-                             (lookup-key sp-keymap (vector last-command-event)))
-                    (delete-char -1)
-                    (sp--call-fallback-command)
-                    (setq action t))))
+                (when (and (not (sp--this-original-command-self-insert-p))
+                           (lookup-key sp-keymap (vector last-command-event)))
+                  (delete-char -1)
+                  (sp--call-fallback-command)
+                  (setq action t)))
               ;; if nothing happened, we just inserted a character, so
               ;; set the apropriate operation.  We also need to check
               ;; for `sp--self-insert-no-escape' not to overwrite
@@ -2538,7 +2626,10 @@ would execute if smartparens-mode were disabled."
               (when (and (eq sp-last-operation 'sp-self-insert)
                          sp-point-inside-string
                          sp-autoescape-string-quote
-                         (eq (preceding-char) ?\"))
+                         (or (and (eq (preceding-char) ?\")
+                                  (eq sp-point-inside-string ?\"))
+                             (and (eq (preceding-char) ?')
+                                  (eq sp-point-inside-string ?'))))
                 (save-excursion
                   (backward-char 1)
                   (insert sp-escape-char))))))
@@ -2620,10 +2711,11 @@ the current context."
   (--filter (and (sp--do-action-p (car it) 'navigate)
                  (equal (car it) (cdr it))) sp-pair-list))
 
-(defun sp--get-pair-list-context ()
+(defun sp--get-pair-list-context (&optional action)
   "Return all pairs that are recognized in this `major-mode' and
 are allowed in the current context."
-  (--filter (sp--do-action-p (car it) 'insert) sp-pair-list))
+  (setq action (or action 'insert))
+  (--filter (sp--do-action-p (car it) action) sp-pair-list))
 
 (defun sp--get-pair-list-wrap ()
   "Return the list of all pairs that can be used for wrapping."
@@ -3155,59 +3247,63 @@ followed by word.  It is disabled by default.  See
              active-pair
              (sp--wrap-repeat-last active-pair))
         sp-last-operation
-      (if (not (and sp-autoinsert-pair
-                    active-pair
-                    (not (and (eq sp-last-operation 'sp-skip-closing-pair)
-                              (sp--get-active-overlay 'pair)))
-                    (if (eq sp-autoskip-closing-pair 'always)
-                        (or (not (equal open-pair close-pair))
-                            (not (sp-skip-closing-pair nil t)))
-                      t)
-                    (sp--do-action-p open-pair 'insert t)
-                    (if sp-autoinsert-if-followed-by-word t
-                      (or (= (point) (point-max))
-                          (not (and (eq (char-syntax (following-char)) ?w)
-                                    (not (eq (following-char) ?\'))))))
-                    (if sp-autoinsert-quote-if-followed-by-closing-pair t
-                      (if (and (eq (char-syntax (preceding-char)) ?\")
-                               ;; this is called *after* the character is
-                               ;; inserted.  Therefore, if we are not in string, it
-                               ;; must have been closed just now
-                               (not (sp-point-in-string)))
-                          (let ((pattern (sp--get-closing-regexp)))
-                            ;; If we simply insert closing ", we also
-                            ;; don't want to escape it.  Therefore, we
-                            ;; need to set `sp-last-operation'
-                            ;; accordingly to be checked in
-                            ;; `self-insert-command' advice.
-                            (if (sp--looking-at pattern)
-                                (progn (setq sp-last-operation 'sp-self-insert-no-escape) nil)
+      (if (not (unwind-protect
+                   (progn
+                     (when pair (insert pair))
+                     (and sp-autoinsert-pair
+                          active-pair
+                          (not (and (eq sp-last-operation 'sp-skip-closing-pair)
+                                    (sp--get-active-overlay 'pair)))
+                          (if (eq sp-autoskip-closing-pair 'always)
+                              (or (not (equal open-pair close-pair))
+                                  (not (sp-skip-closing-pair nil t)))
+                            t)
+                          (sp--do-action-p open-pair 'insert t)
+                          (if sp-autoinsert-if-followed-by-word t
+                            (or (= (point) (point-max))
+                                (not (and (eq (char-syntax (following-char)) ?w)
+                                          (not (eq (following-char) ?\'))))))
+                          (if sp-autoinsert-quote-if-followed-by-closing-pair t
+                            (if (and (eq (char-syntax (preceding-char)) ?\")
+                                     ;; this is called *after* the character is
+                                     ;; inserted.  Therefore, if we are not in string, it
+                                     ;; must have been closed just now
+                                     (not (sp-point-in-string)))
+                                (let ((pattern (sp--get-closing-regexp)))
+                                  ;; If we simply insert closing ", we also
+                                  ;; don't want to escape it.  Therefore, we
+                                  ;; need to set `sp-last-operation'
+                                  ;; accordingly to be checked in
+                                  ;; `self-insert-command' advice.
+                                  (if (sp--looking-at pattern)
+                                      (progn (setq sp-last-operation 'sp-self-insert-no-escape) nil)
+                                    t))
                               t))
-                        t))
-                    (cond
-                     ((eq sp-autoinsert-if-followed-by-same 0) t)
-                     ((eq sp-autoinsert-if-followed-by-same 1)
-                      (not (sp--looking-at (sp--strict-regexp-quote open-pair))))
-                     ((eq sp-autoinsert-if-followed-by-same 2)
-                      (or (not (sp--looking-at (sp--strict-regexp-quote open-pair)))
-                          (and (equal open-pair close-pair)
-                               (eq sp-last-operation 'sp-insert-pair)
-                               (save-excursion
-                                 (backward-char 1)
-                                 (sp--looking-back (sp--strict-regexp-quote open-pair))))))
-                     ((eq sp-autoinsert-if-followed-by-same 3)
-                      (or (not (sp--get-active-overlay 'pair))
-                          (not (sp--looking-at (sp--strict-regexp-quote open-pair)))
-                          (and (equal open-pair close-pair)
-                               (eq sp-last-operation 'sp-insert-pair)
-                               (save-excursion
-                                 (backward-char (length trig))
-                                 (sp--looking-back (sp--strict-regexp-quote open-pair))))
-                          (not (equal open-pair close-pair)))))
-                    (not (run-hook-with-args-until-success
-                          'sp-autoinsert-inhibit-functions
-                          open-pair
-                          (or sp-point-inside-string (sp-point-in-comment))))))
+                          (cond
+                           ((eq sp-autoinsert-if-followed-by-same 0) t)
+                           ((eq sp-autoinsert-if-followed-by-same 1)
+                            (not (sp--looking-at (sp--strict-regexp-quote open-pair))))
+                           ((eq sp-autoinsert-if-followed-by-same 2)
+                            (or (not (sp--looking-at (sp--strict-regexp-quote open-pair)))
+                                (and (equal open-pair close-pair)
+                                     (eq sp-last-operation 'sp-insert-pair)
+                                     (save-excursion
+                                       (backward-char 1)
+                                       (sp--looking-back (sp--strict-regexp-quote open-pair))))))
+                           ((eq sp-autoinsert-if-followed-by-same 3)
+                            (or (not (sp--get-active-overlay 'pair))
+                                (not (sp--looking-at (sp--strict-regexp-quote open-pair)))
+                                (and (equal open-pair close-pair)
+                                     (eq sp-last-operation 'sp-insert-pair)
+                                     (save-excursion
+                                       (backward-char (length trig))
+                                       (sp--looking-back (sp--strict-regexp-quote open-pair))))
+                                (not (equal open-pair close-pair)))))
+                          (not (run-hook-with-args-until-success
+                                'sp-autoinsert-inhibit-functions
+                                 open-pair
+                                 (or sp-point-inside-string (sp-point-in-comment))))))
+                 (when pair (delete-char (- (length pair))))))
           ;; if this pair could not be inserted, we try the procedure
           ;; again with this pair removed from sp-pair-list to give
           ;; chance to other pairs sharing a common suffix (for
@@ -3238,11 +3334,20 @@ followed by word.  It is disabled by default.  See
           (when (and sp-autoescape-string-quote
                      sp-point-inside-string
                      (or
-                      (and (equal open-pair "\"") (equal close-pair "\""))
-                      (and (equal open-pair "'") (equal close-pair "'")))
+                      (and (equal open-pair "\"") (equal close-pair "\"")
+                           (eq sp-point-inside-string ?\"))
+                      (and (equal open-pair "'") (equal close-pair "'")
+                           (eq sp-point-inside-string ?')))
                      (or (not (memq major-mode sp-autoescape-string-quote-if-empty))
-                         ;; test if the string is empty here
-                         (not (sp-point-in-empty-string))))
+                         ;; Test if the string is empty here, by which
+                         ;; we mean the point is surrounded by the
+                         ;; string delimiters.  This enables us to
+                         ;; write e.g. """""" in python docs.
+                         (cl-flet ((check-quote (delimiter)
+                                                (and (equal (char-after (1+ (point))) delimiter)
+                                                     (equal (char-before (1- (point))) delimiter))))
+                           (not (or (check-quote ?\")
+                                    (check-quote ?'))))))
             (save-excursion
               (backward-char 1)
               (insert sp-escape-char)
@@ -3587,32 +3692,51 @@ pairs!"
   (let ((case-fold-search nil))
     (search-forward-regexp regexp bound noerror count)))
 
-(defmacro sp--get-bounds (name docstring test)
-  "Generate a function called NAME that return the bounds of
-object bounded by TEST."
-  (declare (indent 1)
-           (debug (&define name stringp def-form)))
-  `(defun ,name ()
-     ,docstring
-     (when ,test
-       (let ((open (save-excursion
-                     (while (and ,test (not (bobp)))
-                       (forward-char -1))
-                     (if (bobp) (point) (1+ (point)))))
-             (close (save-excursion
-                      (while (and ,test (not (eobp)))
-                        (forward-char 1))
-                      (if (eobp) (point) (1- (point))))))
-         (cons open close)))))
-
-(sp--get-bounds sp-get-quoted-string-bounds
+(defun sp-get-quoted-string-bounds ()
   "If the point is inside a quoted string, return its bounds."
-  (nth 3 (syntax-ppss)))
+  (when (nth 3 (syntax-ppss))
+    (let ((open (save-excursion
+                  (while (and (not (bobp))
+                              (nth 3 (syntax-ppss)))
+                    (backward-char 1))
+                  (point)))
+          (close (save-excursion
+                   (while (and (not (eobp))
+                               (nth 3 (syntax-ppss)))
+                     (forward-char 1))
+                   (point))))
+      (cons open close))))
 
-(sp--get-bounds sp-get-comment-bounds
+;; TODO: the repeated conditions are ugly, refactor this!
+(defun sp-get-comment-bounds ()
   "If the point is inside a comment, return its bounds."
-  (or (sp-point-in-comment)
-      (looking-at "[[:space:]]+;;")))
+  (when (or (sp-point-in-comment)
+            (looking-at "[[:space:]]+\\s<"))
+    (let ((open (save-excursion
+                  (while (and (not (bobp))
+                              (or (sp-point-in-comment)
+                                  (save-excursion
+                                    (backward-char 1)
+                                    (looking-at "[[:space:]]+\\s<"))))
+                    (backward-char 1))
+                  (when (not (or (bobp)
+                                 (or (sp-point-in-comment)
+                                     (save-excursion
+                                       (backward-char 1)
+                                       (looking-at "[[:space:]]+\\s<")))))
+                    (forward-char))
+                  (point)))
+          (close (save-excursion
+                   (while (and (not (eobp))
+                               (or (sp-point-in-comment)
+                                   (looking-at "[[:space:]]+\\s<")))
+                     (forward-char 1))
+                   (when (not (or (eobp)
+                                  (or (sp-point-in-comment)
+                                      (looking-at "[[:space:]]+\\s<"))))
+                     (backward-char 1))
+                   (point))))
+      (cons open close))))
 
 (defun sp--get-string-or-comment-bounds ()
   "Get the bounds of string or comment the point is in."
@@ -3669,6 +3793,7 @@ Non-nil return value means to skip the result."
                     (not (sp--looking-back "\\?\\\\\\\\" 3 t)))
                (and (not (sp-point-in-string-or-comment))
                     (sp--looking-back "\\?" 1 t) ;;TODO surely we can do better
+                    (not (sp--looking-back "\\\\\\?" 2 t))
                     (not (sp--looking-back "\\s_\\?" 2 t))
                     (not (sp--looking-back "\\sw\\?" 2 t))))))))
 
@@ -3687,16 +3812,31 @@ Non-nil return value means to skip the result."
 
 The expressions considered are those delimited by pairs on
 `sp-pair-list'."
-  (let* ((search-fn (if (not back) 'sp--search-forward-regexp 'sp--search-backward-regexp))
-         (global-skip-fn (cdr (--first (memq major-mode (car it)) sp-navigate-skip-match)))
-         (pair-list (sp--get-allowed-pair-list))
-         (in-string-or-comment (sp-point-in-string-or-comment))
-         (string-bounds (and in-string-or-comment (sp--get-string-or-comment-bounds)))
-         (fw-bound (if in-string-or-comment (cdr string-bounds) (point-max)))
-         (bw-bound (if in-string-or-comment (car string-bounds) (point-min)))
-         s e active-pair forward mb me ms r done
-         possible-pairs possible-interfering-pairs possible-ops possible-cls)
-    (save-excursion
+  (save-excursion
+    (let* ((search-fn (if (not back) 'sp--search-forward-regexp 'sp--search-backward-regexp))
+           (global-skip-fn (cdr (--first (memq major-mode (car it)) sp-navigate-skip-match)))
+           (pair-list (sp--get-allowed-pair-list))
+           ;; TODO UGLY HACK!!!  When the situation is:
+           ;; ..)|;; comment
+           ;; the context the point gets is the comment.  But if we
+           ;; are searching backward, that is incorrect, because in
+           ;; that case we want the context of the closing pair.
+           ;; Therefore, if the direction is backward, we need to move
+           ;; one point backward, then test the comment/string thing,
+           ;; then compute the correct bounds, and then restore the
+           ;; point so the search will pick up the )
+           (in-string-or-comment (-if-let (soc (sp-point-in-string-or-comment))
+                                     (if back
+                                         (save-excursion
+                                           (backward-char)
+                                           (sp-point-in-string-or-comment))
+                                       soc)
+                                   soc))
+           (string-bounds (and in-string-or-comment (sp--get-string-or-comment-bounds)))
+           (fw-bound (if in-string-or-comment (cdr string-bounds) (point-max)))
+           (bw-bound (if in-string-or-comment (car string-bounds) (point-min)))
+           s e active-pair forward mb me ms r done
+           possible-pairs possible-interfering-pairs possible-ops possible-cls)
       (while (not done)
         ;; search for the first opening pair.  Here, only consider tags
         ;; that are allowed in the current context.
@@ -3705,14 +3845,18 @@ The expressions considered are those delimited by pairs on
                                    (if back bw-bound fw-bound)
                                    r mb me ms)
         (unless (sp--skip-match-p ms mb me :global-skip global-skip-fn)
-          (when (not (sp-point-in-string-or-comment))
+          (when (not (if (not back)
+                         (sp-point-in-string-or-comment (1- (point)))
+                       (sp-point-in-string-or-comment)))
             (setq in-string-or-comment nil))
           ;; if the point originally wasn't inside of a string or comment
           ;; but now is, jump out of the string/comment and only search
           ;; the code.  This ensures that the comments and strings are
           ;; skipped if we search inside code.
           (if (and (not in-string-or-comment)
-                   (sp-point-in-string-or-comment))
+                   (if (not back)
+                       (sp-point-in-string-or-comment (1- (point)))
+                     (sp-point-in-string-or-comment)))
               (let* ((bounds (sp--get-string-or-comment-bounds))
                      (jump-to (if back (1- (car bounds)) (1+ (cdr bounds)))))
                 (goto-char jump-to))
@@ -3760,7 +3904,10 @@ The expressions considered are those delimited by pairs on
             (sp--search-and-save-match search-fn needle b r mb me ms)
             (if r
                 (unless (or (and (not in-string-or-comment)
-                                 (sp-point-in-string-or-comment))
+                                 (if forward (save-excursion
+                                               (backward-char)
+                                               (sp-point-in-string-or-comment))
+                                   (sp-point-in-string-or-comment)))
                             ;; check the individual pair skipper.  We
                             ;; need to test all the possible-ops,
                             ;; which makes it a bit ugly :/
@@ -3770,7 +3917,7 @@ The expressions considered are those delimited by pairs on
                   (when (--any? (equal ms it) opens) (setq depth (1+ depth)))
                   (when (--any? (equal ms it) closes) (setq depth (1- depth))))
               (unless (minibufferp)
-                (message "Search failed.  This means there is unmatched expression somewhere or we are at the beginning/end of file."))
+                (sp-message :unmatched-expression))
               (setq depth -1)
               (setq failure t)))
           (if forward
@@ -3781,22 +3928,23 @@ The expressions considered are those delimited by pairs on
                   (/= depth 0))
               (progn
                 (unless (minibufferp)
-                  (message "Search failed.  This means there is unmatched expression somewhere or we are at the beginning/end of file."))
+                  (sp-message :unmatched-expression))
                 nil)
-            (cond
-             ((or (and (sp-point-in-string-or-comment s) (not (sp-point-in-string-or-comment e)))
-                  (and (not (sp-point-in-string-or-comment s)) (sp-point-in-string-or-comment e)))
-              (unless (minibufferp)
-                (message "Opening or closing pair is inside a string or comment and matching pair is outside (or vice versa).  Ignored."))
-              nil)
-             (t
-              (let* ((op (if forward open close)))
-                (list :beg s
-                      :end e
-                      :op op
-                      :cl (if forward close open)
-                      :prefix (sp--get-prefix s op)
-                      :suffix (sp--get-suffix e op)))))))))))
+            (let ((end-in-cos (sp-point-in-string-or-comment (1- e)))) ;; fix the "point on comment" issue
+              (cond
+               ((or (and (sp-point-in-string-or-comment s) (not end-in-cos))
+                    (and (not (sp-point-in-string-or-comment s)) end-in-cos))
+                (unless (minibufferp)
+                  (sp-message :delimiter-in-string))
+                nil)
+               (t
+                (let* ((op (if forward open close)))
+                  (list :beg s
+                        :end e
+                        :op op
+                        :cl (if forward close open)
+                        :prefix (sp--get-prefix s op)
+                        :suffix (sp--get-suffix e op))))))))))))
 
 ;; TODO: this does not consider unbalanced quotes in comments!!!
 (defun sp--find-next-stringlike-delimiter (needle search-fn-f &optional limit skip-fn)
@@ -3988,14 +4136,14 @@ See `sp-get-hybrid-sexp' for definition."
   "Get the end of hybrid sexp.
 See `sp-get-hybrid-sexp' for definition."
   (save-excursion
-    (flet ((skip-prefix-backward
-            (p)
-            (save-excursion
-              (goto-char p)
-              (save-restriction
-                (sp--narrow-to-line)
-                (skip-syntax-backward " .")
-                (point)))))
+    (cl-flet ((skip-prefix-backward
+               (p)
+               (save-excursion
+                 (goto-char p)
+                 (save-restriction
+                   (sp--narrow-to-line)
+                   (skip-syntax-backward " .")
+                   (point)))))
       (let ((p (progn (when (sp-point-in-symbol) (sp-backward-sexp)) (point)))
             (le (line-end-position))
             (cur (--if-let (save-excursion (sp-forward-sexp)) it (list :beg (1+ (point-max))))) ;hack
@@ -4215,13 +4363,17 @@ This function simply transforms BOUNDS, which is a cons (BEG
 . END) into format compatible with `sp-get-sexp'."
   (let* ((bob (= (point-min) (car bounds)))
          (eob (= (point-max) (cdr bounds)))
-         (cl (char-to-string (char-after (if eob (1- (cdr bounds)) (cdr bounds))))))
-    (list :beg (if bob (car bounds) (1- (car bounds)))
-          :end (if eob (cdr bounds) (1+ (cdr bounds)))
-          :op cl
-          :cl cl
-          :prefix ""
-          :suffix "")))
+         ;; if the closing and opening isn't the same token, we should
+         ;; return nil
+         (op (char-to-string (char-after (car bounds))))
+         (cl (char-to-string (char-before (cdr bounds)))))
+    (when (equal op cl)
+      (list :beg (car bounds)
+            :end (cdr bounds)
+            :op cl
+            :cl cl
+            :prefix ""
+            :suffix ""))))
 
 (defun sp-get-string (&optional back)
   "Find the nearest string after point, or before if BACK is non-nil.
@@ -4241,8 +4393,8 @@ returned by `sp-get-sexp'."
           (sp--get-string r))
       (save-excursion
         (sp-skip-into-string back)
-        (let ((r (sp-get-quoted-string-bounds)))
-          (when r (sp--get-string r)))))))
+        (--when-let (sp-get-quoted-string-bounds)
+          (sp--get-string it))))))
 
 (defun sp-get-whitespace ()
   "Get the whitespace around point.
@@ -4307,7 +4459,7 @@ and newline."
                   (if forward (setq depth (1- depth)) (setq depth (1+ depth))))
               (setq depth -1)))
           (if (eq depth -1)
-              (progn (message "Search failed. No matching tag found.") nil)
+              (progn (sp-message :no-matching-tag) nil)
             (save-excursion
               (if forward
                   (progn
@@ -5047,12 +5199,18 @@ Examples:
                       ;; if the expression is empty remove everything inside
                       (if (sp-compare-sexps ok prev)
                           (sp-get ok (delete-region :beg-in :end-in))
-                        (delete-region (sp-get prev :end) (point)))))
+                        (when (save-excursion
+                                (skip-chars-backward " \t\n")
+                                (= (point) (sp-get prev :end-suf)))
+                          (delete-region (sp-get prev :end-suf) (point))))))
                 (goto-char (sp-get ok :beg-in))
                 (let ((next (sp-get-thing)))
                   (if (sp-compare-sexps ok next)
                       (sp-get ok (delete-region :beg-in :end-in))
-                    (delete-region (point) (sp-get next :beg))))))))
+                    (when (save-excursion
+                            (skip-chars-forward " \t\n")
+                            (= (point) (sp-get next :beg-prf)))
+                      (delete-region (point) (sp-get next :beg-prf)))))))))
       ;; on forward up, we can detect that the pair was not closed.
       ;; Therefore, jump sexps backwards until we hit the error, then
       ;; extract the opening pair and insert it at point.  Only works
@@ -5284,6 +5442,14 @@ t.  All the special prefix arguments work the same way."
   (save-excursion
     (sp-kill-sexp (sp--negate-argument arg) t)))
 
+(defun sp-clone-sexp ()
+  (interactive)
+  (-when-let (ok (sp-get-thing))
+    (sp-get ok
+      (goto-char :end-suf)
+      (sp-newline)
+      (insert (buffer-substring-no-properties :beg-prf :end-suf)))))
+
 (defun sp-kill-hybrid-sexp (arg)
   "Kill a line as if with `kill-line', but respecting delimiters.
 
@@ -5436,7 +5602,7 @@ Examples:
                    (sp-backward-sexp)
                    (sp-get-hybrid-sexp))))
       (if (sp-compare-sexps prev next > :end)
-          (message "Invalid context: previous h-sexp ends after the next one.")
+          (sp-message :invalid-context-prev)
         (sp--transpose-objects prev next))
       (when (looking-at "[\n\t ]+")
         (forward-line)
@@ -5461,7 +5627,7 @@ Examples:
                  (sp-forward-sexp)
                  (sp-get-hybrid-sexp))))
     (if (sp-compare-sexps cur next >)
-        (message "Invalid context: current h-sexp starts after the next one.")
+        (sp-message :invalid-context-cur)
       (sp--transpose-objects cur next))))
 
 ;; The following two functions are inspired by "adjust-parens.el"
@@ -5482,7 +5648,7 @@ handling of empty lines."
                       (sp-get-sexp t))))
     (if (not (and prev-sexp hsexp
                   (sp-compare-sexps prev-sexp hsexp < :end :beg)))
-        (message "Previous sexp starts after current hsexp or no structure was found.")
+        (sp-message :no-structure-found)
       (save-excursion
         (sp-get prev-sexp
           (goto-char (sp-get hsexp :end))
@@ -5584,13 +5750,15 @@ triggers that `sp-forward-slurp-sexp' does."
                        (+ :beg-in (save-excursion
                                     (goto-char :beg-in)
                                     (skip-syntax-forward " ")))))))
-          (when (not (looking-at "[ \t]*$"))
+          (unless (or (looking-at "[ \t]*$")
+                      (looking-at (sp--get-stringlike-regexp))
+                      (looking-at (sp--get-closing-regexp)))
             (newline)))
         (sp-get (sp--next-thing-selection -1) (indent-region :beg :end))
         ;; we need to call this again to get the new structure after
         ;; indent.
         (sp--next-thing-selection -1))
-    (message "This operation would result in invalid structure. Ignored.")
+    (sp-message :invalid-structure)
     nil))
 
 
@@ -5675,7 +5843,7 @@ Examples:
                         (when (= (sp-get enc :beg) (sp-get ok :beg)) (plist-put enc :end (point)))
                         (sp--run-hook-with-args (sp-get enc :op) :post-handlers 'slurp-forward))
                       (setq n (1- n)))
-                  (message "We can't slurp without breaking strictly balanced expression. Ignored.")
+                  (sp-message :cant-slurp)
                   (setq n -1)))))))
     (sp-backward-slurp-sexp (sp--negate-argument arg))))
 
@@ -5753,7 +5921,7 @@ Examples:
                         (when (sp-compare-sexps enc ok) (plist-put enc :beg (- (point) (sp-get ok :op-l))))
                         (sp--run-hook-with-args (sp-get enc :op) :post-handlers 'slurp-backward))
                       (setq n (1- n)))
-                  (message "We can't slurp without breaking strictly balanced expression. Ignored.")
+                  (sp-message :cant-slurp)
                   (setq n -1)))))))
     (sp-forward-slurp-sexp (sp--negate-argument arg))))
 
@@ -5850,7 +6018,7 @@ Examples: (prefix arg in comment)
          (arg (prefix-numeric-value arg)))
     (if (> arg 0)
         (if (sp-point-in-blank-sexp)
-            (message "Point is in blank sexp, nothing to barf")
+            (sp-message :blank-sexp)
           (save-excursion
             (let ((enc (sp-get-enclosing-sexp)))
               (sp-get enc
@@ -5894,7 +6062,7 @@ Examples:
          (arg (prefix-numeric-value arg)))
     (if (> arg 0)
         (if (sp-point-in-blank-sexp)
-            (message "Point is in blank sexp, nothing to barf")
+            (sp-message :blank-sexp)
           (save-excursion
             (let ((enc (sp-get-enclosing-sexp)))
               (sp-get enc
@@ -5927,7 +6095,8 @@ Examples:
         (forward-fn (if forward 'forward-char 'backward-char))
         (next-char-fn (if forward 'following-char 'preceding-char))
         (looking (if forward 'sp--looking-at 'sp--looking-back))
-        (eob-test (if forward '(eobp) '(bobp))))
+        (eob-test (if forward '(eobp) '(bobp)))
+        (comment-bound (if forward 'cdr 'car)))
     `(let ((in-comment (sp-point-in-comment))
            ;; HACK: if we run out of current context this might skip a
            ;; pair that was not allowed before.  However, such a call is
@@ -5949,7 +6118,10 @@ Examples:
                                  (,looking allowed-strings))))
                    (or (member (char-syntax (,next-char-fn)) '(?< ?> ?! ?| ?\ ?\\ ?\" ?' ?.))
                        (unless in-comment (sp-point-in-comment))))
-         (,forward-fn 1)))))
+         (when (and (not in-comment)
+                    (sp-point-in-comment))
+           (goto-char (,comment-bound (sp-get-comment-bounds))))
+         (when (not ,eob-test) (,forward-fn 1))))))
 
 (defun sp-skip-forward-to-symbol (&optional stop-at-string stop-after-string stop-inside-string)
   "Skip whitespace and comments moving forward.
@@ -6177,7 +6349,7 @@ Examples:
           (sp-get encp (goto-char :beg-prf))
           (sp-get enc (insert :prefix :op))
           (sp-get encp (delete-char (+ :op-l :prefix-l))))
-      (message "Point has to be at least two levels deep to swap the enclosing delimiters."))))
+      (sp-message :point-not-deep-enough))))
 
 (defun sp--unwrap-sexp (sexp &optional no-cleanup)
   "Unwrap expression defined by SEXP.
@@ -6711,7 +6883,7 @@ Return the information about resulting expression."
               :op (sp-get prev :op)
               :cl (sp-get prev :cl)
               :prefix (sp-get prev :prefix)))
-    (message "The expressions to be joined are of different type.")))
+    (sp-message :different-type)))
 
 (defun sp-join-sexp (&optional arg)
   "Join the sexp before and after point if they are of the same type.
@@ -7032,7 +7204,7 @@ Examples:
          ((and (sp-point-in-string)
                (save-excursion (forward-char) (not (sp-point-in-string))))
           (setq n 0))
-         ((sp--looking-at (sp--get-opening-regexp (sp--get-pair-list-context)))
+         ((sp--looking-at (sp--get-opening-regexp (sp--get-pair-list-context 'navigate)))
           (if (save-match-data (sp-get-thing))
               (goto-char (match-end 0))
             (delete-char (length (match-string 0))))
@@ -7043,7 +7215,7 @@ Examples:
           (forward-char)
           ;; make this customizable
           (setq n (1- n)))
-         ((sp--looking-at (sp--get-closing-regexp (sp--get-pair-list-context)))
+         ((sp--looking-at (sp--get-closing-regexp (sp--get-pair-list-context 'navigate)))
           (if (save-match-data (sp-get-thing))
               ;; make this customizable -- maybe we want to skip and
               ;; continue deleting
@@ -7107,7 +7279,7 @@ Examples:
          ((and (sp-point-in-string)
                (save-excursion (backward-char) (not (sp-point-in-string))))
           (setq n 0))
-         ((sp--looking-back (sp--get-closing-regexp (sp--get-pair-list-context)))
+         ((sp--looking-back (sp--get-closing-regexp (sp--get-pair-list-context 'navigate)))
           (if (save-match-data (sp-get-thing t))
               (goto-char (match-beginning 0))
             (delete-char (- (length (match-string 0)))))
@@ -7118,7 +7290,7 @@ Examples:
           (backward-char)
           ;; make this customizable
           (setq n (1- n)))
-         ((sp--looking-back (sp--get-opening-regexp (sp--get-pair-list-context)))
+         ((sp--looking-back (sp--get-opening-regexp (sp--get-pair-list-context 'navigate)))
           (if (save-match-data (sp-get-thing t))
               ;; make this customizable -- maybe we want to skip and
               ;; continue deleting
@@ -7142,7 +7314,7 @@ delimiter enclosing this sexp."
   (setq pos (or pos (point)))
   (let (op act)
     (cond
-     ((sp--looking-back (sp--get-opening-regexp (sp--get-pair-list-context)))
+     ((sp--looking-back (sp--get-opening-regexp (sp--get-pair-list-context 'navigate)))
       (setq op (match-string 0))
       (setq act (--first (equal (car it) op) sp-pair-list))
       (when (sp--looking-at (regexp-quote (cdr act))) act))
@@ -7465,17 +7637,11 @@ support custom pairs."
              (allowed (and sp-show-pair-from-inside (sp--get-allowed-regexp)))
              ok match)
         (cond
-         ((or
-           (sp--looking-at (if sp-show-pair-from-inside allowed opening))
-           (and (or
-                 (and (memq major-mode sp-navigate-consider-stringlike-sexp)
-                      (looking-at (sp--get-stringlike-regexp)))
-                 (and (memq major-mode sp-navigate-consider-sgml-tags)
-                      (looking-at "<")))
-                ;; We only want to match string-like delimiters or '<' if
-                ;; they are opening a sexp
-                (eq (point) (sp-get (sp-get-thing) :beg))
-                ))
+         ((or (sp--looking-at (if sp-show-pair-from-inside allowed opening))
+              (and (memq major-mode sp-navigate-consider-stringlike-sexp)
+                   (looking-at (sp--get-stringlike-regexp)))
+              (and (memq major-mode sp-navigate-consider-sgml-tags)
+                   (looking-at "<")))
           (setq match (match-string 0))
           ;; we can use `sp-get-thing' here because we *are* at some
           ;; pair opening, and so only the tag or the sexp can trigger.

--- a/smartparens.el
+++ b/smartparens.el
@@ -7465,11 +7465,19 @@ support custom pairs."
              (allowed (and sp-show-pair-from-inside (sp--get-allowed-regexp)))
              ok match)
         (cond
-         ((or (sp--looking-at (if sp-show-pair-from-inside allowed opening))
-              (and (memq major-mode sp-navigate-consider-stringlike-sexp)
-                   (looking-at (sp--get-stringlike-regexp)))
-              (and (memq major-mode sp-navigate-consider-sgml-tags)
-                   (looking-at "<")))
+         (
+          (or
+          (sp--looking-at (if sp-show-pair-from-inside allowed opening))
+          (and
+           (or
+            (and (memq major-mode sp-navigate-consider-stringlike-sexp)
+                 (looking-at (sp--get-stringlike-regexp)))
+            (and (memq major-mode sp-navigate-consider-sgml-tags)
+                 (looking-at "<")))
+           ;; We only want to match string-like delimiters or '<' if
+           ;; they are opening a sexp
+           (eq (point) (sp-get (sp-get-thing) :beg))
+          ))
           (setq match (match-string 0))
           ;; we can use `sp-get-thing' here because we *are* at some
           ;; pair opening, and so only the tag or the sexp can trigger.

--- a/smartparens.el
+++ b/smartparens.el
@@ -1332,14 +1332,12 @@ beginning."
   "Return non-nil if `this-command' is some sort of `self-insert-command'."
   (memq this-command '(self-insert-command
                        org-self-insert-command
-                       orgtbl-self-insert-command
                        sp--self-insert-command)))
 
 (defun sp--this-original-command-self-insert-p ()
   "Return non-nil if `this-original-command' is some sort of `self-insert-command'."
   (memq this-original-command '(self-insert-command
                                 org-self-insert-command
-                                orgtbl-self-insert-command
                                 sp--self-insert-command)))
 
 (defun sp--signum (x)
@@ -2610,11 +2608,12 @@ would execute if smartparens-mode were disabled."
               ;; That is a function that would normally run if SP was
               ;; inactive. TODO: should this be customizable?
               (when (not action)
-                (when (and (not (sp--this-original-command-self-insert-p))
-                           (lookup-key sp-keymap (vector last-command-event)))
-                  (delete-char -1)
-                  (sp--call-fallback-command)
-                  (setq action t)))
+                (let ((fb-fun (sp--keybinding-fallback)))
+                  (when (and (not (eq fb-fun 'self-insert-command))
+                             (lookup-key sp-keymap (vector last-command-event)))
+                    (delete-char -1)
+                    (sp--call-fallback-command)
+                    (setq action t))))
               ;; if nothing happened, we just inserted a character, so
               ;; set the apropriate operation.  We also need to check
               ;; for `sp--self-insert-no-escape' not to overwrite

--- a/smartparens.el
+++ b/smartparens.el
@@ -7465,19 +7465,17 @@ support custom pairs."
              (allowed (and sp-show-pair-from-inside (sp--get-allowed-regexp)))
              ok match)
         (cond
-         (
-          (or
-          (sp--looking-at (if sp-show-pair-from-inside allowed opening))
-          (and
-           (or
-            (and (memq major-mode sp-navigate-consider-stringlike-sexp)
-                 (looking-at (sp--get-stringlike-regexp)))
-            (and (memq major-mode sp-navigate-consider-sgml-tags)
-                 (looking-at "<")))
-           ;; We only want to match string-like delimiters or '<' if
-           ;; they are opening a sexp
-           (eq (point) (sp-get (sp-get-thing) :beg))
-          ))
+         ((or
+           (sp--looking-at (if sp-show-pair-from-inside allowed opening))
+           (and (or
+                 (and (memq major-mode sp-navigate-consider-stringlike-sexp)
+                      (looking-at (sp--get-stringlike-regexp)))
+                 (and (memq major-mode sp-navigate-consider-sgml-tags)
+                      (looking-at "<")))
+                ;; We only want to match string-like delimiters or '<' if
+                ;; they are opening a sexp
+                (eq (point) (sp-get (sp-get-thing) :beg))
+                ))
           (setq match (match-string 0))
           ;; we can use `sp-get-thing' here because we *are* at some
           ;; pair opening, and so only the tag or the sexp can trigger.

--- a/smartparens.el
+++ b/smartparens.el
@@ -1338,6 +1338,7 @@ beginning."
   "Return non-nil if `this-original-command' is some sort of `self-insert-command'."
   (memq this-original-command '(self-insert-command
                                 org-self-insert-command
+                                orgtbl-self-insert-command
                                 sp--self-insert-command)))
 
 (defun sp--signum (x)
@@ -2608,12 +2609,11 @@ would execute if smartparens-mode were disabled."
               ;; That is a function that would normally run if SP was
               ;; inactive. TODO: should this be customizable?
               (when (not action)
-                (let ((fb-fun (sp--keybinding-fallback)))
-                  (when (and (not (eq fb-fun 'self-insert-command))
-                             (lookup-key sp-keymap (vector last-command-event)))
-                    (delete-char -1)
-                    (sp--call-fallback-command)
-                    (setq action t))))
+                (when (and (not (sp--this-original-command-self-insert-p))
+                           (lookup-key sp-keymap (vector last-command-event)))
+                  (delete-char -1)
+                  (sp--call-fallback-command)
+                  (setq action t)))
               ;; if nothing happened, we just inserted a character, so
               ;; set the apropriate operation.  We also need to check
               ;; for `sp--self-insert-no-escape' not to overwrite


### PR DESCRIPTION
I hope I didn't break anything. It seems to work in latex, but a similar bug happens with sgml tags, and this doesn't fix it (I suspect it is because the `<` is considered the opening pair of the `</foo>` tag).

If `sp-get-thing` is a slow function, then this "fix" is also highly non-optimized. There is probably a better way to check that we are at the beginning of a sexp anyway.
