### PR TITLE
Two spaces after a period

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -30,11 +30,11 @@
 ;;; Commentary:
 
 ;; Smartparens is minor mode for Emacs that deals with parens pairs
-;; and tries to be smart about it. It started as a unification effort
+;; and tries to be smart about it.  It started as a unification effort
 ;; to combine functionality of several existing packages in a single,
 ;; compatible and extensible way to deal with parentheses, delimiters,
-;; tags and the like. Some of these packages include autopair,
-;; textmate, wrap-region, electric-pair-mode, paredit and others. With
+;; tags and the like.  Some of these packages include autopair,
+;; textmate, wrap-region, electric-pair-mode, paredit and others.  With
 ;; the basic features found in other packages it also brings many
 ;; improvements as well as completely new features.
 


### PR DESCRIPTION
The documentation later in the file uses two spaces after a period to 
designate the end of a sentence, so now the header will follow suit.
