### PR TITLE
Add scheme-interaction-mode to sp--lisp-modes

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -424,6 +424,7 @@ Symbol is defined as a chunk of text recognized by
                          inferior-emacs-lisp-mode
                          lisp-interaction-mode
                          scheme-mode
+                         scheme-interaction-mode
                          inferior-scheme-mode
                          geiser-repl-mode
                          lisp-mode


### PR DESCRIPTION
Scheme Interaction mode defined in xscheme.el, which is distributed with MIT/GNU Scheme.
