### PR TITLE
Fix sp-kill-hybrid-sexp bug in REPL-like modes

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -5556,7 +5556,9 @@ Examples:
       ;; to just one space
       (when (sp-point-in-blank-line)
         (delete-region (line-beginning-position) (line-end-position))
-        (insert (make-string orig-indent ?\ )))))))
+        (let ((need-indent (- orig-indent (current-column))))
+          (when (> need-indent 0)
+            (insert (make-string need-indent ?\ )))))))))
 
 (defun sp--transpose-objects (first second)
   "Transpose FIRST and SECOND object while preserving the


### PR DESCRIPTION
After killing a full line (i.e. `sp-point-in-blank-line` returns non-nil), `sp-kill-hybrid-sexp` inserts a number of spaces equal to the value of `(current-column)` before the kill was performed. When killing a full line in a mode where the editable line begins at a non-zero column this causes extraneous spaces to be inserted.

Instead, only insert the spaces (if any) necessary to get point back to the original indentation level recorded before the kill.
