### PR TITLE
Don't cleanup whitespace for some modes

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -448,6 +448,11 @@ Symbol is defined as a chunk of text recognized by
                          )
   "List of HTML modes.")
 
+(defvar sp--indentation-sensitive-modes '(
+                         python-mode
+                         )
+  "List of modes that are indentation sensitive.")
+
 (defvar sp-message-alist
   '((:unmatched-expression
      "Search failed. This means there is unmatched expression somewhere or we are at the beginning/end of file."
@@ -7437,7 +7442,8 @@ See `sp-forward-symbol' for what constitutes a symbol."
                       (if word
                           (kill-region kill-from (save-excursion (forward-word) (point)))
                         (kill-region kill-from :end)))))))))
-        (sp--cleanup-after-kill)
+        (unless (memq major-mode sp--indentation-sensitive-modes)
+          (sp--cleanup-after-kill))
         (setq arg (1- arg)))
     (sp-backward-kill-symbol (sp--negate-argument arg) word)))
 
@@ -7478,7 +7484,8 @@ See `sp-backward-symbol' for what constitutes a symbol."
                     (if word
                         (kill-region (save-excursion (backward-word) (point)) :end)
                       (kill-region :beg-prf :end))))))))
-        (sp--cleanup-after-kill)
+        (unless (memq major-mode sp--indentation-sensitive-modes)
+          (sp--cleanup-after-kill))
         (setq arg (1- arg)))
     (sp-kill-symbol (sp--negate-argument arg) word)))
 


### PR DESCRIPTION
Modes that use indention like Python mode aren't able to correctly
determine what level of indentation to return to, so it's better to not
to eat all the whitespace after killing words.

Basically the behavior that this changes can be demonstrated as

`^` indicates the location of the cursor

before

``` python
for l in lines:
    if out:
        res['total'] = int(out.group(1))
    if l.startswith("="):
      ^
```

after `sp-backward-kill-word`

``` python
for l in lines:
    if out:
        res['total'] = int(out.group(1))
  l.startswith("="):
  ^
```

after applying this patch and `sp-backward-kill-word`

``` python
for l in lines:
    if out:
        res['total'] = int(out.group(1))
     l.startswith("="):
    ^
```
