### PR TITLE
Check for nil in advice for ac-complete

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -7815,7 +7815,7 @@ support custom pairs."
 (defadvice ac-complete (after sp-auto-complete-advice activate)
   "If `smartparens-mode' is active, we check if the completed string
 has a pair definition.  If so, we insert the closing pair."
-  (when smartparens-mode
+  (when (and smartparens-mode ad-return-value) ; `ac-complete' returns nil if there are no completion candidates.
     (setq sp-recent-keys (reverse (split-string ad-return-value "")))
     (sp-insert-pair))
   ad-return-value)


### PR DESCRIPTION
This fixes the "split-string: Wrong type argument: stringp, nil" error when ac-complete is called and there are no completion candidates.

The fixed error breaks ac-js2-expand-function (from the ac-js2 package), which calls ac-complete internally.
