### PR TITLE
Don't reindent after kill for some modes.

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -440,7 +440,9 @@ Symbol is defined as a chunk of text recognized by
                                              coffee-mode
                                              js2-mode
                                              )
-  "List of modes that should not reindent after kill.")
+  "List of modes that should not reindent after kill."
+  :type '(repeat symbol)
+  :group 'smartparens)
 
 (defvar sp--html-modes '(
                          sgml-mode

--- a/smartparens.el
+++ b/smartparens.el
@@ -436,6 +436,11 @@ Symbol is defined as a chunk of text recognized by
                          common-lisp-mode)
   "List of Lisp modes.")
 
+(defvar sp--no-reindent-after-kill-modes '(
+                                           coffee-mode
+                                           js2-mode)
+  "List of modes that should not reindent after kill.")
+
 (defvar sp--html-modes '(
                          sgml-mode
                          html-mode
@@ -5438,15 +5443,16 @@ Note: prefix argument is shown after the example in
                   (buffer-substring-no-properties bdel edel)
                 "")))
       (delete-region bdel edel)))
-  (if (memq major-mode sp--lisp-modes)
-      (indent-according-to-mode)
-    (save-excursion
-      (indent-region (line-beginning-position) (line-end-position)))
-    (when (> (save-excursion
-               (back-to-indentation)
-               (current-indentation))
-             (current-column))
-      (back-to-indentation))))
+  (unless (memq major-mode sp--no-reindent-after-kill-modes)
+    (if (memq major-mode sp--lisp-modes)
+        (indent-according-to-mode)
+      (save-excursion
+        (indent-region (line-beginning-position) (line-end-position)))
+      (when (> (save-excursion
+                 (back-to-indentation)
+                 (current-indentation))
+               (current-column))
+        (back-to-indentation)))))
 
 (defun sp-backward-kill-sexp (&optional arg dont-kill)
   "Kill the balanced expression preceding point.

--- a/smartparens.el
+++ b/smartparens.el
@@ -436,9 +436,10 @@ Symbol is defined as a chunk of text recognized by
                          common-lisp-mode)
   "List of Lisp modes.")
 
-(defvar sp--no-reindent-after-kill-modes '(
-                                           coffee-mode
-                                           js2-mode)
+(defcustom sp-no-reindent-after-kill-modes '(
+                                             coffee-mode
+                                             js2-mode
+                                             )
   "List of modes that should not reindent after kill.")
 
 (defvar sp--html-modes '(
@@ -5443,9 +5444,9 @@ Note: prefix argument is shown after the example in
                   (buffer-substring-no-properties bdel edel)
                 "")))
       (delete-region bdel edel)))
-  (unless (memq major-mode sp--no-reindent-after-kill-modes)
-    (if (memq major-mode sp--lisp-modes)
-        (indent-according-to-mode)
+  (if (memq major-mode sp--lisp-modes)
+      (indent-according-to-mode)
+    (unless (memq major-mode sp-no-reindent-after-kill-modes)
       (save-excursion
         (indent-region (line-beginning-position) (line-end-position)))
       (when (> (save-excursion


### PR DESCRIPTION
Indentation in [coffee-mode](https://github.com/defunkt/coffee-mode) is not very smart, it just cycles through possible indentations. So automatically reindenting after a kill mostly results in a correctly indented line becoming incorrectly indented.

This is an attempt to fix that behavior. If there is another, better way to do it, please let me know!