### PR TITLE
Improve sp-region-ok-p

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -7512,15 +7512,39 @@ of the point."
         (indent-sexp))
       (sp--back-to-indentation column indentation))))
 
+
+(defun sp--unbalanced-string-after-point-p ()
+  (push major-mode sp-navigate-consider-stringlike-sexp)
+  (save-excursion
+    (unwind-protect
+        (let ((str (ignore-errors (sp-get-string))))
+          (when str
+            (goto-char (plist-get str :beg))
+            (sp-down-sexp)
+            (if (= (point) (save-excursion (sp-up-sexp) (point)))
+                t
+              nil)))
+      (progn (pop sp-navigate-consider-stringlike-sexp) nil))))
+
 (defun sp-region-ok-p (start end)
   (save-excursion
     (save-restriction
       (narrow-to-region start end)
       (goto-char (point-min))
-      (let ((r t))
-        (while (and r (not (eobp)))
-          (setq r (sp-forward-sexp)))
-        r))))
+      (cond
+       ((sp--unbalanced-string-after-point-p) nil)
+       ;; A region without any pairs is trivially ok
+       ((and (not (save-excursion
+                    (re-search-forward (sp--get-opening-regexp (sp--get-pair-list-context))
+                                       nil :noerror)))
+             (not (save-excursion
+                    (re-search-forward (sp--get-closing-regexp (sp--get-pair-list-context))
+                                       nil :noerror))))
+        t)
+       (t (let ((r t))
+            (while (and r (not (eobp)))
+              (setq r (sp-forward-sexp)))
+            r))))))
 
 (defun sp-newline ()
   "Insert a newline and indent it.

--- a/tests/smartparens-test.el
+++ b/tests/smartparens-test.el
@@ -103,6 +103,23 @@ executing `sp-skip-closing-pair'."
         (execute-kbd-macro "\""))
       (should (equal (buffer-string) "def foo():\n    \"\"\"\"\"\"")))))
 
+(defun sp-test--string-valid-p (str)
+  (with-temp-buffer
+    (insert str)
+    (sp-region-ok-p (point-min) (point-max))))
+
+(ert-deftest sp-test-region-ok-unbalanced-paren ()
+  (should-not (sp-test--string-valid-p "foo)")))
+
+(ert-deftest sp-test-region-ok-unbalanced-string ()
+  (should-not (sp-test--string-valid-p "foo\"")))
+
+(ert-deftest sp-test-region-ok-balanced-string ()
+  (should (sp-test--string-valid-p "\"foo\"")))
+
+(ert-deftest sp-test-region-ok-balanced-parens ()
+  (should (sp-test--string-valid-p "(foo)")))
+
 (defun sp-test-run-tests ()
   (interactive)
   (ert "sp-test-*"))


### PR DESCRIPTION
The following edge-cases have been fixed:

* Regions that were trivially ok because they didn't contain any opening
  or closing pairs.
* Regions containing an unbalanced string.

Closes #405