### PR TITLE
Remote nrepl-repl-mode from sp--lisp-modes

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -432,7 +432,6 @@ Symbol is defined as a chunk of text recognized by
                          eshell-mode
                          slime-repl-mode
                          cider-repl-mode
-                         nrepl-repl-mode
                          clojure-mode
                          common-lisp-mode)
   "List of Lisp modes.")


### PR DESCRIPTION
This mode was renamed to cider-repl-mode about 1 year ago, so I think we can safely remove it.