### PR TITLE
improve-sp-region-ok for trailing ws and comment

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -7427,10 +7427,20 @@ of the point."
               nil)))
       (progn (pop sp-navigate-consider-stringlike-sexp) nil))))
 
+;;; Taken from subr-x.el
+(defsubst string-trim-right (string)
+  "Remove trailing whitespace from STRING."
+  (if (string-match "[ \t\n\r]+\\'" string)
+      (replace-match "" t t string)
+    string))
+
 (defun sp-region-ok-p (start end)
-  (save-excursion
-    (save-restriction
-      (narrow-to-region start end)
+  (let ((region (string-trim-right (buffer-substring-no-properties start end))))
+    (with-temp-buffer
+      (insert region)
+      (-when-let (bounds (and (sp-point-in-comment)
+                              (sp-get-comment-bounds)))
+        (delete-region (first bounds) (second bound)))
       (goto-char (point-min))
       (cond
        ((sp--unbalanced-string-after-point-p) nil)

--- a/tests/smartparens-test.el
+++ b/tests/smartparens-test.el
@@ -120,6 +120,12 @@ executing `sp-skip-closing-pair'."
 (ert-deftest sp-test-region-ok-balanced-parens ()
   (should (sp-test--string-valid-p "(foo)")))
 
+(ert-deftest sp-test-region-ok-trailing-ws ()
+  (should (sp-test--string-valid-p "(foo)	  \n")))
+
+(ert-deftest sp-test-region-ok-trailing-comment ()
+  (should (sp-test--string-valid-p "(foo) ; foo")))
+
 (defun sp-test-run-tests ()
   (interactive)
   (ert "sp-test-*"))


### PR DESCRIPTION
Regions with trailing ws or comments would not be validated as OK.