### PR TITLE
 support python.el as well as python-mode.el

### DIFF
--- a/smartparens-config.el
+++ b/smartparens-config.el
@@ -100,7 +100,8 @@
 (eval-after-load "lua-mode"      '(require 'smartparens-lua))
 (eval-after-load "ruby-mode"     '(require 'smartparens-ruby))
 (eval-after-load "enh-ruby-mode" '(require 'smartparens-ruby))
-(eval-after-load "python-mode"   '(require 'smartparens-python))
+(--each '("python-mode" "python")
+  (eval-after-load it '(require 'smartparens-python)))
 
 (provide 'smartparens-config)
 


### PR DESCRIPTION
Note: I didn't add a sp--python-modes variable since python.el and python-mode.el both provide python-mode, so that wouldn't make sense.