### PR TITLE
Where sp-kil-hybrid-sexp wasn't killing whitespace and it is now fixed. 

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -1008,10 +1008,14 @@ by specifying its :suffix property."
 
 ;; hybrid lines
 (defcustom sp-hybrid-kill-excessive-whitespace nil
-  "If non-nil, `sp-kill-hybrid-sexp' will kill all whitespace up
-until next hybrid sexp if the point is at the end of line or on a
-blank line."
-  :type 'boolean
+  "If non-nil, `sp-kill-hybrid-sexp' will delete all whitespace
+up until next hybrid sexp if the point is at the end of line or
+on a blank line. When argument is 'kill whitespace will meld to
+deleted sexp in kill ring."
+  :type '(choice
+          (const :tag "On" t)
+          (const :tag "Kill" kill)
+          (const :tag "Off" nil))
   :group 'smartparens)
 
 (defcustom sp-hybrid-kill-entire-symbol nil
@@ -5194,8 +5198,10 @@ Examples:
               (when sp-hybrid-kill-excessive-whitespace
                 (save-excursion (goto-char end)
                   (skip-chars-forward "\n\t\r\s")
-                  (setq end (point))))
-              (back-to-indentation)
+                  (cond ((eq 'kill sp-hybrid-kill-excessive-whitespace)
+                         (setq end (point)))
+                        (t (delete-region end (point)))))
+                (back-to-indentation))
               (kill-region (point) end)))))
       (sp--cleanup-after-kill)
       ;; if we've killed the entire line, do *not* contract the indent

--- a/smartparens.el
+++ b/smartparens.el
@@ -5201,8 +5201,7 @@ Examples:
                   (skip-chars-forward "\n\t\r\s")
                   (cond ((eq 'kill sp-hybrid-kill-excessive-whitespace)
                          (setq end (point)))
-                        (t (delete-region end (point)))))
-                (back-to-indentation))
+                        (t (delete-region end (point))))))
               (kill-region (point) end)))))
       (sp--cleanup-after-kill)
       ;; if we've killed the entire line, do *not* contract the indent

--- a/smartparens.el
+++ b/smartparens.el
@@ -5193,8 +5193,9 @@ Examples:
                      (sp-point-in-symbol))
             (sp-backward-sexp))
           (sp-get hl
-            (let ((end (min (point-max)(if (looking-at "[ \t]*$")
-                                           (1+ :end-suf) :end-suf))))
+            (let ((end (min (point-max) (if (looking-at "[ \t]*$")
+                                            (1+ :end-suf)
+                                          :end-suf))))
               (when sp-hybrid-kill-excessive-whitespace
                 (save-excursion (goto-char end)
                   (skip-chars-forward "\n\t\r\s")

--- a/smartparens.el
+++ b/smartparens.el
@@ -5189,15 +5189,14 @@ Examples:
                      (sp-point-in-symbol))
             (sp-backward-sexp))
           (sp-get hl
-            (kill-region (point) (min (point-max) (if (looking-at "[ \t]*$") (1+ :end-suf) :end-suf)))
-            (when sp-hybrid-kill-excessive-whitespace
-              (cond
-               ((sp-point-in-blank-line)
-                (while (and (not (eobp))
-                            (sp-point-in-blank-line))
-                  (delete-region (line-beginning-position) (min (point-max) (1+ (line-end-position))))))
-               ((looking-at "[ \t]*$")
-                (delete-blank-lines)))))))
+            (let ((end (min (point-max)(if (looking-at "[ \t]*$")
+                                           (1+ :end-suf) :end-suf))))
+              (when sp-hybrid-kill-excessive-whitespace
+                (save-excursion (goto-char end)
+                  (skip-chars-forward "\n\t\r\s")
+                  (setq end (point))))
+              (back-to-indentation)
+              (kill-region (point) end)))))
       (sp--cleanup-after-kill)
       ;; if we've killed the entire line, do *not* contract the indent
       ;; to just one space


### PR DESCRIPTION
This change makes `sp-kill-hybrid-sexp` to kill a region of variable length depending on whitespace and value of `sp-hybrid-kill-excessive-whitespace'. 

By attracting both kill-region and delete-region into single command it was made possible to make this data available in kill ring without losses.
