### PR TITLE
sp-clone-sexp will no longer dash ahead.

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -5135,11 +5135,15 @@ t.  All the special prefix arguments work the same way."
 
 (defun sp-clone-sexp ()
   (interactive)
-  (-when-let (ok (sp-get-thing))
+  (-when-let (ok (or (sp-get-enclosing-sexp)
+                     (sp-get-sexp)))
     (sp-get ok
-      (goto-char :end-suf)
-      (sp-newline)
-      (insert (buffer-substring-no-properties :beg-prf :end-suf)))))
+      (save-excursion
+        (undo-boundary)
+        (goto-char :beg-prf)
+        (insert-buffer-substring-no-properties
+         (current-buffer) :beg-prf :end-suf)
+        (newline-and-indent)))))
 
 (defun sp-kill-hybrid-sexp (arg)
   "Kill a line as if with `kill-line', but respecting delimiters.


### PR DESCRIPTION
This function had issues with relative cursor position which made it distance itself further and further from original context. This is fixed version, as well as taking some liberties in deciding what most useful context would be. 
The behavior of `sp-get-sexp` responsible for choosing its targets reflects on this command in a way that delimits its usefulness. Especially in the root context, where `sp-get-enclosing-sexp` doesn't shine with efficiency either.