### PR TITLE
Fix point at wrong side of bound error

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -3390,7 +3390,7 @@ longest possible match.  That means that searching for
 This is an internal function.  Only use this for searching for
 pairs!"
   (setq count (or count 1))
-  (setq bound (or bound (sp--get-forward-bound)))
+  (setq bound (or bound (sp--get-backward-bound)))
   (let ((case-fold-search nil) r)
     (while (> count 0)
       (when (search-backward-regexp regexp bound noerror)
@@ -3402,7 +3402,7 @@ pairs!"
 
 (defun sp--search-forward-regexp (regexp &optional bound noerror count)
   "Just like `search-forward-regexp', but always case sensitive."
-  (setq bound (or bound (sp--get-backward-bound)))
+  (setq bound (or bound (sp--get-forward-bound)))
   (let ((case-fold-search nil))
     (search-forward-regexp regexp bound noerror count)))
 


### PR DESCRIPTION
The functions `sp--search-{forward,backward}-regexp` appear to have had
their bounds reversed.

Does the seem right to you, @tmccombs?