### PR TITLE
sp-splice-sexp: also avoid indenting here on certain modes

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -6511,8 +6511,9 @@ represent a valid object in a buffer!"
           (let ((b (bounds-of-thing-at-point 'line)))
             (delete-region (car b) (cdr b))))
         (setq indent-from (point)))
-      (sp--keep-indentation
-        (indent-region indent-from indent-to)))))
+      (unless (memq major-mode sp-no-reindent-after-kill-modes)
+        (sp--keep-indentation
+          (indent-region indent-from indent-to))))))
 
 (defun sp-unwrap-sexp (&optional arg)
   "Unwrap the following expression.


### PR DESCRIPTION
Until #493 is resolved, this should make some Haskellers happy.

---

Often in refactoring we remove parentheses in Haskell, e.g. in this case using `sp-splice-sexp`, but haskell-mode indentation suffers from the same problem for that we have had in `sp-kill-sexp`. For example:

```haskell
import Control.Monad
import System.Directory
import System.FilePath

main = do
    content <- getDirectoryContents "."
    forM_ content $ \filename -> do
        let filenameInDir = ("." </> filename)
        print filenameInDir
```

Before this change, `sp-splice-sexp` inside the parentheses would result in:

```haskell
    forM_ content $ \filename -> do
         let filenameInDir = "." </> filename
        print filenameInDir
```

Which breaks compilation. It should be:

```haskell
    forM_ content $ \filename -> do
        let filenameInDir = "." </> filename
        print filenameInDir
```