### PR TITLE
Ensure turn-off-smartparens-mode also disables strict mode.

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -715,9 +715,16 @@ in mode's startup-hook etc.) by calling `smartparens-mode'."
 
 ;;;###autoload
 (defun turn-off-smartparens-mode ()
-  "Turn off `smartparens-mode'."
+  "Turn off `smartparens-mode'.
+See also `turn-off-smartparens-trict-mode'."
   (interactive)
   (smartparens-mode -1))
+
+;;;###autoload
+(defun turn-off-smartparens-strict-mode ()
+  "Turn off `smartparens-mode' and `smartparens-strict-mode'."
+  (interactive)
+  (smartparens-strict-mode -1))
 
 ;; insert custom
 (defcustom sp-autoinsert-pair t


### PR DESCRIPTION
I've started using smartparens-strict-mode, and it works really well. However, I noticed my calls to `turn-off-smartparens-mode` didn't disable strict mode. This fixes that.

I think this is a reasonable behaviour, let me know what you think.
