### PR TITLE
Don't ignore errors when running :when and :unless functions.

### DIFF
--- a/smartparens-config.el
+++ b/smartparens-config.el
@@ -53,16 +53,19 @@
 
 (defun sp-lisp-invalid-hyperlink-p (_1 action _2)
   (when (eq action 'navigate)
-    (or (and (looking-at "\\sw\\|\\s_")
-             (save-excursion
-               (backward-char 2)
-               (looking-at "\\sw\\|\\s_")))
-        (and (save-excursion
-               (backward-char 1)
-               (looking-at "\\sw\\|\\s_"))
-             (save-excursion
-               (forward-char 1)
-               (looking-at "\\sw\\|\\s_"))))))
+    ;; Ignore errors due to us being at the start or end of the
+    ;; buffer.
+    (ignore-errors
+      (or (and (looking-at "\\sw\\|\\s_")
+               (save-excursion
+                 (backward-char 2)
+                 (looking-at "\\sw\\|\\s_")))
+          (and (save-excursion
+                 (backward-char 1)
+                 (looking-at "\\sw\\|\\s_"))
+               (save-excursion
+                 (forward-char 1)
+                 (looking-at "\\sw\\|\\s_")))))))
 
 ;; emacs is lisp hacking enviroment, so we set up some most common
 ;; lisp modes too

--- a/smartparens.el
+++ b/smartparens.el
@@ -2506,9 +2506,9 @@ If USE-INSIDE-STRING is non-nil, use value of
       (setq r (when (memq a actions)
                 ;;(and (when-clause) (not (unless-clause)))
                 (and (or (not when-l)
-                         (ignore-errors (run-hook-with-args-until-success 'when-l id a context)))
+                         (run-hook-with-args-until-success 'when-l id a context))
                      (or (not unless-l)
-                         (not (ignore-errors (run-hook-with-args-until-success 'unless-l id a context)))))))
+                         (not (run-hook-with-args-until-success 'unless-l id a context))))))
       (!cdr action))
     r))
 


### PR DESCRIPTION
Otherwise, this can lead to very hard-to-debug errors.

Consider the code:

    (defun always-true (id context)
      t)

    (sp-with-modes '(some-mode)
      (sp-local-pair "[" "]" :unless '(always-true)))

We would expect [ to never be automatically paired. However,
`always-true` only takes 2 arguments, when it should take 3. As a
result, we swallow the error and consider `always-true` to have returned
nil!

This made my debugging tricky, so I believe throwing the error
sooner is the right thing to do here.