### PR TITLE
Clarify testing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,10 @@
 EMACS ?= emacs
 CASK ?= cask
-ECUKES ?= ecukes
-#$(shell find elpa/ecukes-*/ecukes | tail -1)
 
-test: unit-tests #ecukes-features
+test: unit-tests
 
 unit-tests: elpa
 	${CASK} exec ert-runner
-
-ecukes-features: elpa
-	${CASK} exec ${ECUKES} --no-win
 
 elpa:
 	mkdir -p elpa
@@ -26,6 +21,5 @@ clean: clean-elpa clean-elc
 print-deps:
 	${EMACS} --version
 	@echo CASK=${CASK}
-	@echo ECUKES=${ECUKES}
 
 travis-ci: print-deps test

--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ in your configuration files (e.g. init.el) to load it.  There are also files wit
 
 *Note: `smartparens-config` automatically loads the core smartparens files, so you don't have to require those separately.*
 
+# Testing
+
+Smarparens uses [ert-runner](https://github.com/rejeep/ert-runner.el)
+for testing. To run all the tests, run:
+
+```
+$ make test
+```
+
+Alternatively, you can open the individual files in Emacs, then
+`M-x eval-buffer` `M-x ert`.
+
+There are also some ecukes tests, but these are deprecated.
+
 # Support the project
 
 If you want to support this project, you can do it in the following ways:


### PR DESCRIPTION
Document how to run tests, and remove the remaining bits of ecukes.

Closes #515.