### PR TITLE
When slurping forward, don't include punctuation at end of line.

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -5919,7 +5919,6 @@ triggers that `sp-forward-slurp-sexp' does."
           (when (sp-point-in-blank-line)
             (delete-region (line-beginning-position) (1+ (line-end-position))))
           (sp-forward-sexp)
-          (sp-get (sp-get-hybrid-sexp) (goto-char :end-suf))
           (insert :cl :suffix))
         ;; TODO: move to hook
         (sp-get (sp--next-thing-selection -1)
@@ -5938,11 +5937,7 @@ triggers that `sp-forward-slurp-sexp' does."
                        :beg-in
                        (+ :beg-in (save-excursion
                                     (goto-char :beg-in)
-                                    (skip-syntax-forward " ")))))))
-          (unless (or (looking-at "[ \t]*$")
-                      (looking-at (sp--get-stringlike-regexp))
-                      (looking-at (sp--get-closing-regexp)))
-            (newline)))
+                                    (skip-syntax-forward " "))))))))
         (sp-get (sp--next-thing-selection -1) (sp--indent-region :beg :end))
         ;; we need to call this again to get the new structure after
         ;; indent.

--- a/test/smartparens-js-test.el
+++ b/test/smartparens-js-test.el
@@ -1,0 +1,5 @@
+(ert-deftest sp-test-slurp-excludes-semicolon ()
+  (sp-test-with-temp-buffer "var foo = bar(|)baz;"
+      (js-mode)
+    (sp-slurp-hybrid-sexp)
+    (should (equal (buffer-string) "var foo = bar(baz);"))))

--- a/test/smartparens-python-test.el
+++ b/test/smartparens-python-test.el
@@ -1,3 +1,5 @@
+(require 'smartparens)
+
 (ert-deftest sp-test-sp-autoescape-string-quote-if-empty ()
   (sp-test-with-temp-buffer "def foo():\n    |"
       (python-mode)
@@ -17,3 +19,15 @@ baz = biz.boz|"
     (should (equal (buffer-string) "if foo:
     bar()
 baz = biz."))))
+
+(ert-deftest sp-test-slurp-exclude-colon ()
+  (sp-test-with-temp-buffer "if bar(|)foo:"
+      (python-mode)
+    (sp-slurp-hybrid-sexp)
+    (should (equal (buffer-string) "if bar(foo):"))))
+
+(ert-deftest sp-test-slurp-include-dot ()
+  (sp-test-with-temp-buffer "(|foo).bar"
+      (python-mode)
+    (sp-slurp-hybrid-sexp)
+    (should (equal (buffer-string) "(foo.bar)"))))


### PR DESCRIPTION
Fixes #534.

I think this is a reasonable change -- all of the tests still pass. I'm not sure what the `(newline)` call was intended to achieve. Removing it hasn't broken anything obvious to me.