### PR TITLE
Ensure that we can kill Rust words at the beginning of a buffer.

### DIFF
--- a/smartparens-rust.el
+++ b/smartparens-rust.el
@@ -48,10 +48,13 @@
   "Return t if point is in a Rust context where ' represents a lifetime.
 If we return nil, ' should be used for character literals."
   (or
-   ;; If point is just after a &', it's probably a &'foo.
-   (save-excursion
-     (backward-char 2)
-     (looking-at "&"))
+   (condition-case nil
+       ;; If point is just after a &', it's probably a &'foo.
+       (save-excursion
+         (backward-char 2)
+         (looking-at "&"))
+     ;; If we're at the beginning of the buffer, just carry on.
+     (beginning-of-buffer))
    ;; If point is inside < > it's probably a parameterised function.
    (let ((paren-pos (nth 1 (syntax-ppss))))
      (and paren-pos

--- a/test/smartparens-rust-test.el
+++ b/test/smartparens-rust-test.el
@@ -22,3 +22,10 @@
     (execute-kbd-macro "'a")
     (should (equal (buffer-string) "let x = 'a'"))))
 
+(ert-deftest sp-test-rust-kill-first-line ()
+  "Ensure we can kill words on the first line.
+Regression test."
+  (sp-test-with-temp-buffer "extern|"
+      (rust-mode)
+    (sp-backward-kill-word 1)
+    (should (equal (buffer-string) ""))))


### PR DESCRIPTION
Minor bug, added a test case.

@Fuco1 is this sufficiently boring that you're happy with me committing directly into master, or do you prefer PRs for fixes like this?