### PR TITLE
Catch errors when running sp--post-self-insert-hook-handler

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -2730,31 +2730,32 @@ see `sp-pair' for description."
 ;; figure out how to detect the argument to self-insert-command that
 ;; resulted to this insertion
 (defun sp--post-self-insert-hook-handler ()
-  (when smartparens-mode
-    (let (op action)
-      (setq op sp-last-operation)
-      (when (region-active-p)
-        (sp-wrap--initialize))
-      (cond
-       (sp-wrap-overlays
-        (sp-wrap))
-       (t
-        ;; TODO: this does not pick correct pair!! it uses insert and not wrapping code
-        (sp--setaction action (-when-let ((_ . open-pairs) (sp--all-pairs-to-insert))
-                                (catch 'done
-                                  (-each open-pairs
-                                    (-lambda ((&keys :open open :close close))
-                                      (--when-let (sp--wrap-repeat-last (cons open close))
-                                        (throw 'done it)))))))
-        (sp--setaction action (sp-insert-pair))
-        (sp--setaction action (sp-skip-closing-pair))
-        ;; if nothing happened, we just inserted a character, so
-        ;; set the apropriate operation.  We also need to check
-        ;; for `sp--self-insert-no-escape' not to overwrite
-        ;; it.  See `sp-autoinsert-quote-if-followed-by-closing-pair'.
-        (when (and (not action)
-                   (not (eq sp-last-operation 'sp-self-insert-no-escape)))
-          (setq sp-last-operation 'sp-self-insert)))))))
+  (with-demoted-errors "sp--post-self-insert-hook-handler: %S"
+    (when smartparens-mode
+      (let (op action)
+        (setq op sp-last-operation)
+        (when (region-active-p)
+          (sp-wrap--initialize))
+        (cond
+         (sp-wrap-overlays
+          (sp-wrap))
+         (t
+          ;; TODO: this does not pick correct pair!! it uses insert and not wrapping code
+          (sp--setaction action (-when-let ((_ . open-pairs) (sp--all-pairs-to-insert))
+                                  (catch 'done
+                                    (-each open-pairs
+                                      (-lambda ((&keys :open open :close close))
+                                        (--when-let (sp--wrap-repeat-last (cons open close))
+                                          (throw 'done it)))))))
+          (sp--setaction action (sp-insert-pair))
+          (sp--setaction action (sp-skip-closing-pair))
+          ;; if nothing happened, we just inserted a character, so
+          ;; set the apropriate operation.  We also need to check
+          ;; for `sp--self-insert-no-escape' not to overwrite
+          ;; it.  See `sp-autoinsert-quote-if-followed-by-closing-pair'.
+          (when (and (not action)
+                     (not (eq sp-last-operation 'sp-self-insert-no-escape)))
+            (setq sp-last-operation 'sp-self-insert))))))))
 
 ;; Unfortunately, some modes rebind "inserting" keys to their own
 ;; handlers but do not hand over the insertion back to


### PR DESCRIPTION
This should help us to debug when this function is erroring, and will
ensure that Emacs does not remove the handler unexpectedly.

#481