### PR TITLE
Pair < with > in parameterized Rust function calls.

### DIFF
--- a/smartparens-rust.el
+++ b/smartparens-rust.el
@@ -66,7 +66,7 @@ If we return nil, ' should be used for character literals."
   "Return t if we could add a <T> in this position.
 If nil, the user is probably using < for something else."
   (and (apply #'sp-in-code-p args)
-       (looking-back (rx (or letter (seq letter "<"))))))
+       (looking-back (rx (or letter (seq letter "<") (seq letter "::<"))))))
 
 (sp-with-modes '(rust-mode)
   (sp-local-pair "'" "'" :unless '(sp-in-comment-p sp-in-rust-lifetime-context))

--- a/test/smartparens-rust-test.el
+++ b/test/smartparens-rust-test.el
@@ -76,3 +76,11 @@ Regression test."
       (rust-mode)
     (execute-kbd-macro "<")
     (should (equal (buffer-string) "println!(\"{:0<}\", x);"))))
+
+(ert-deftest sp-test-rust-pair-angle-bracket-in-function-call ()
+  "Pair < when parameterizing function calls."
+  (sp-test-with-temp-buffer "iterator.collect::|"
+      (rust-mode)
+    (execute-kbd-macro "<")
+    ;; We should have inserted a pair.
+    (should (equal (buffer-string) "iterator.collect::<>"))))


### PR DESCRIPTION
This fixes an oversight in pairing angle brackets in Rust when parameterizing function calls, such as `iterator.collect::<Vec<u32>>()`.

By the way, thank you for this excellent package. :smile: 