### PR TITLE
Don't insert whitespace when slurping in Python.

### DIFF
--- a/smartparens-python.el
+++ b/smartparens-python.el
@@ -53,5 +53,24 @@
 (--each '(python-mode inferior-python-mode)
   (add-to-list 'sp-sexp-suffix (list it 'regexp "")))
 
+(sp-local-pair 'python-mode
+               "(" nil
+               :pre-handlers '(sp-python-pre-slurp-handler))
+
+(sp-local-pair 'python-mode
+               "[" nil
+               :pre-handlers '(sp-python-pre-slurp-handler))
+
+(defun sp-python-pre-slurp-handler (id action context)
+  (when (eq action 'slurp-forward)
+    ;; If there was no space before, we shouldn't add on.
+    ;; ok = enclosing, next-thing one being slurped into
+    ;; (variables let-bound in `sp-forward-slurp-sexp').
+    (save-excursion
+      (when (and (= (sp-get ok :end) (sp-get next-thing :beg))
+                 (equal (sp-get ok :op) (sp-get next-thing :op)))
+        (goto-char (sp-get ok :end))
+        (when (looking-back " ")
+          (delete-char -1))))))
 (provide 'smartparens-python)
 ;;; smartparens-python.el ends here

--- a/test/smartparens-python-test.el
+++ b/test/smartparens-python-test.el
@@ -1,3 +1,4 @@
+(require 'ert)
 (require 'smartparens)
 
 (ert-deftest sp-test-sp-autoescape-string-quote-if-empty ()
@@ -18,3 +19,17 @@ baz = biz.boz|"
     (should (equal (buffer-string) "if foo:
     bar()
 baz = biz."))))
+
+(ert-deftest sp-test-python-slurp-whitespace ()
+  "Ensure we don't add unwanted whitespace when slurping."
+  (sp-test-with-temp-buffer "foo(|bar)(baz)"
+      (python-mode)
+    (sp-forward-slurp-sexp)
+    (should (equal (buffer-string) "foo(bar(baz))"))))
+
+(ert-deftest sp-test-python-square-bracket-whitespace ()
+  "Ensure we don't add unwanted whitespace when slurping."
+  (sp-test-with-temp-buffer "foo[|bar][baz]"
+      (python-mode)
+    (sp-forward-slurp-sexp)
+    (should (equal (buffer-string) "foo[bar[baz]]"))))


### PR DESCRIPTION
Hi @Fuco1

This is just applying the fix you suggested for #236. I think just doing `(` and `[` is reasonable here. I think the code is correct. It's using dynamic scoping so generates a warning, but it does pass the tests.

I've also committed 62429854f7ea919b9610bacb282e756f0bc5befc to make hybrid slurping more discoverable.

