### PR TITLE
Racket: Don't pair quote

### DIFF
--- a/smartparens-racket.el
+++ b/smartparens-racket.el
@@ -48,6 +48,7 @@
 (require 'smartparens)
 
 (sp-with-modes '(racket-mode racket-repl-mode)
+  (sp-local-pair "'" nil :actions nil)
   (sp-local-pair "`" nil :actions nil)
   (sp-local-pair "#|" "|#"))
 


### PR DESCRIPTION
I think quote should be disabled, just like quasiquote already is.

See also: https://github.com/greghendershott/racket-mode/issues/200