### PR TITLE
Ensure that we pair ' in code in Python.

### DIFF
--- a/smartparens-python.el
+++ b/smartparens-python.el
@@ -53,9 +53,17 @@
 (--each '(python-mode inferior-python-mode)
   (add-to-list 'sp-sexp-suffix (list it 'regexp "")))
 
+(defun sp-python-in-string-p (id action context)
+  "Return non-nil if point is in a string, taking
+care not to be confused by an unclosed ' that's just been typed."
+  (and (eq context 'string)
+       (save-excursion
+         (backward-char 1)
+         (nth 3 (syntax-ppss)))))
+
 (sp-local-pair 'python-mode
                "'" "'"
-               :unless '(sp-in-comment-p sp-in-string-p))
+               :unless '(sp-in-comment-p sp-python-in-string-p))
 
 (sp-local-pair 'python-mode
                "(" nil

--- a/test/smartparens-python-test.el
+++ b/test/smartparens-python-test.el
@@ -54,3 +54,10 @@ baz = biz."))))
       (python-mode)
     (execute-kbd-macro "'")
     (should (equal (buffer-string) "# '"))))
+
+(ert-deftest sp-test-python-apostrophe-in-code ()
+  "When inserting ' in code, insert a matching '."
+  (sp-test-with-temp-buffer ""
+      (python-mode)
+    (execute-kbd-macro "'")
+    (should (equal (buffer-string) "''"))))


### PR DESCRIPTION
Fixes #573 and adds a test.

@Fuco1 I'm not sure if this is the right approach. The naive implementation we had before didn't work, but I'm not sure if this is a bug in the smartparens parsing.

```python
# we start with this
x = |

# the user presses '
x = '|

# however, smartparens thinks that point is now in a string, 
# so didn't insert the matching ' !
```

Is there a better approach? Moving around and calling `syntax-ppss` seems hacky but I can't see a better way using just `id` `context` and `action`.