### PR TITLE
sp-select-next-thing should handle buffer limits gracefully.

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -7423,6 +7423,10 @@ considered balanced expressions."
          (b (sp-get selection :beg))
          (e (sp-get selection :end))
          contracted)
+    ;; Show a helpful error if we're trying to move beyond the
+    ;; beginning or end of the buffer.
+    (when (or (null b) (null e))
+      (user-error (if (bobp) "At beginning of buffer" "At end of buffer")))
     ;; if region is active and ready to use, check if this selection
     ;; == old selection.  If so, reselect the insides
     (when (region-active-p)

--- a/test/smartparens-commands-test.el
+++ b/test/smartparens-commands-test.el
@@ -1,3 +1,5 @@
+(require 'smartparens)
+
 (defun sp-test-command-setup ()
   (cond
    ((not (boundp 'mode)) (emacs-lisp-mode))
@@ -538,5 +540,13 @@ be."
       (sp-test-with-temp-elisp-buffer "(fo|o)"
         (let ((unread-command-events (list ?\a)))
           (call-interactively 'sp-rewrap-sexp))
+        (error "We should never get here"))
+    (user-error t)))
+
+(ert-deftest sp-test-command-sp-select-next-thing-empty-buffer ()
+  "Ensure we call user-error at buffer end."
+  (condition-case c
+      (sp-test-with-temp-elisp-buffer ""
+        (call-interactively 'sp-select-next-thing)
         (error "We should never get here"))
     (user-error t)))


### PR DESCRIPTION
Fixes #449.