### PR TITLE
Add memoization for sp--strict-regexp-quote

### DIFF
--- a/Cask
+++ b/Cask
@@ -6,6 +6,7 @@
 
 (depends-on "cl-lib" "0.3")
 (depends-on "dash" "2.12.1")
+(depends-on "memoize" "1.0.1")
 
 (development
   (depends-on "f")

--- a/smartparens-pkg.el
+++ b/smartparens-pkg.el
@@ -1,3 +1,4 @@
 (define-package "smartparens" "1.7.1" "Automatic insertion, wrapping and paredit-like navigation with user defined pairs."
-  '((dash "2.12.1")
+  '((memoize "1.0.1")
+    (dash "2.12.1")
     (cl-lib "0.3")))

--- a/smartparens.el
+++ b/smartparens.el
@@ -53,6 +53,7 @@
 (require 'cl-lib)
 (require 'dash)
 (require 'thingatpt)
+(require 'memoize)
 
 (eval-when-compile (defvar cua--region-keymap))
 (declare-function cua-replace-region "cua-base")
@@ -2885,7 +2886,7 @@ that the strings are not matched in-symbol."
       (mapconcat (lambda (g) (apply 'sp--regexp-for-group g)) it "\\|")
       (concat "\\(?:" it "\\)"))))
 
-(defun sp--strict-regexp-quote (string)
+(defmemoize sp--strict-regexp-quote (string)
   "Like regexp-quote, but make sure that the string is not
 matched in-symbol."
   (sp--wrap-regexp (regexp-quote string)


### PR DESCRIPTION
Fixes #603

To be honest, this didn't seem to make much difference. I couldn't reproduce `sp--strict-regexp-quote` taking up a large number of samples while profiling and adding the memoization in didn't seem to help. Furthermore, the timers created by the memoize package seem to dominate the profiler without actually seeming to impact typing latency (which makes sense, I guess). If I disabled the timers by setting `(setq memoize-default-timeout nil)` they didn't appear in the profile, but since that's a global setting I don't think it makes sense for us to set. It doesn't seem like there's a way with this package to say you don't a timeout for a specific function because of the `(or timeout memoize-default-timeout)`.

Long story short, it'd be great if someone else could measure with [typometer](https://github.com/pavelfatin/typometer) the difference between memoizing and not. It seemed to not matter too much on my machine.

Lastly, if we were going to memoize, I don't think this is the package for it because we probably don't actually want a timeout for this specific function. Adding so many additional timers probably doesn't help anything.
