### PR TITLE
Removed pairing for backtick and apostrophe.

### DIFF
--- a/smartparens-latex.el
+++ b/smartparens-latex.el
@@ -67,12 +67,6 @@
       (goto-char (sp-get sp-last-wrapped-region :beg-in))
       (insert " "))))
 
-(defun sp-latex-skip-match-apostrophe (ms mb me)
-  (when (equal ms "'")
-    (save-excursion
-      (goto-char me)
-      (looking-at-p "\\sw"))))
-
 (defun sp-latex-skip-double-quote (_1 action _2)
   (when (eq action 'insert)
     (when (looking-at-p "''''")
@@ -95,10 +89,6 @@ This predicate is only tested on \"insert\" action."
                  plain-tex-mode
                  latex-mode
                  )
-  (sp-local-pair "`" "'"
-                 :actions '(:rem autoskip)
-                 :skip-match 'sp-latex-skip-match-apostrophe
-                 :unless '(sp-latex-point-after-backslash))
   ;; math modes, yay.  The :actions are provided automatically if
   ;; these pairs do not have global definitions.
   (sp-local-pair "$" "$")


### PR DESCRIPTION
This fixes #611.

It seems that sp-latex-skip-match-apostrophe doesn't perform its stated
function, because placing the cursor before a quote (say, in math mode,
where quote is used to denote a derivative) will result in "Unmatched
expression." showing up in the minibuffer.

Note that smartparens, in an attempt to find the matching backtick for
the single quote, substantially slows down editing in any (La)TeX file
containing unmatched quotes (e.g. derivative f'(x) showing up in math mode).

Since single quotes appear relatively infrequently in English prose, the
loss in functionality is minimal and the speed-up benefit seems to be
worth it.