### PR TITLE
Memoize `syntax-ppss` in a couple places

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -365,7 +365,11 @@ Maximum length of opening or closing pair is
   ;; executes them, then reset the "counter".
   delayed-hook
   ;; TODO
-  delayed-insertion)
+  delayed-insertion
+  ;; The last point checked by sp--syntax-ppss and its result, used for
+  ;; memoization
+  last-syntax-ppss-point
+  last-syntax-ppss-result)
 
 (defvar sp-state nil
   "Smartparens state for the current buffer.")
@@ -1363,11 +1367,11 @@ sexp, otherwise the call may be very slow."
 (defun sp--syntax-ppss (&optional p)
   "Memoize the last result of syntax-ppss."
   (let ((p (or p (point))))
-    (if (eq p sp-last-point)
-        sp-last-syntax-ppss-result
+    (if (eq p (sp-state-last-syntax-ppss-point sp-state))
+        (sp-state-last-syntax-ppss-result sp-state)
       (let ((result (syntax-ppss p)))
-        (setq-local sp-last-point p)
-        (setq-local sp-last-syntax-ppss-result result)
+        (setf (sp-state-last-syntax-ppss-point sp-state) p
+              (sp-state-last-syntax-ppss-result sp-state) result)
         result))))
 
 (defun sp-point-in-string (&optional p)
@@ -8105,10 +8109,6 @@ the opening delimiter or before the closing delimiter."
 (defvar sp-show-pair-overlays nil)
 
 (defvar sp-show-pair-enc-overlays nil)
-
-(defvar-local sp-last-point nil)
-
-(defvar-local sp-last-syntax-ppss-result nil)
 
 ;;;###autoload
 (define-minor-mode show-smartparens-mode

--- a/smartparens.el
+++ b/smartparens.el
@@ -1360,13 +1360,23 @@ sexp, otherwise the call may be very slow."
                    "\\`[ \t\n]*\\'"
                    (buffer-substring-no-properties :beg-in :end-in))))))
 
+(defun sp--syntax-ppss (&optional p)
+  "Memoize the last result of syntax-ppss."
+  (let ((p (or p (point))))
+    (if (eq p sp-last-point)
+        sp-last-syntax-ppss-result
+      (let ((result (syntax-ppss p)))
+        (setq-local sp-last-point p)
+        (setq-local sp-last-syntax-ppss-result result)
+        result))))
+
 (defun sp-point-in-string (&optional p)
   "Return non-nil if point is inside string or documentation string.
 
 If optional argument P is present test this instead of point."
   (ignore-errors
     (save-excursion
-      (nth 3 (syntax-ppss p)))))
+      (nth 3 (sp--syntax-ppss p)))))
 
 (defun sp-point-in-comment (&optional p)
   "Return non-nil if point is inside comment.
@@ -1375,7 +1385,7 @@ If optional argument P is present test this instead off point."
   (setq p (or p (point)))
   (ignore-errors
     (save-excursion
-      (or (nth 4 (syntax-ppss p))
+      (or (nth 4 (sp--syntax-ppss p))
           ;; this also test opening and closing comment delimiters... we
           ;; need to chack that it is not newline, which is in "comment
           ;; ender" class in elisp-mode, but we just want it to be
@@ -8095,6 +8105,10 @@ the opening delimiter or before the closing delimiter."
 (defvar sp-show-pair-overlays nil)
 
 (defvar sp-show-pair-enc-overlays nil)
+
+(defvar-local sp-last-point nil)
+
+(defvar-local sp-last-syntax-ppss-result nil)
 
 ;;;###autoload
 (define-minor-mode show-smartparens-mode

--- a/smartparens.el
+++ b/smartparens.el
@@ -2441,6 +2441,7 @@ should be highlighted."
   "Remove all pair overlays that doesn't have point inside them,
 are of zero length, or if point moved backwards."
   ;; if the point moved backwards, remove all overlays
+  (sp--reset-memoization)
   (if (and sp-cancel-autoskip-on-backward-movement
            (< (point) sp-previous-point))
       (dolist (o sp-pair-overlay-list) (sp--remove-overlay o))
@@ -2452,6 +2453,11 @@ are of zero length, or if point moved backwards."
       (sp--remove-overlay o)))
   (when sp-pair-overlay-list
     (setq sp-previous-point (point))))
+
+(defun sp--reset-memoization ()
+  "Reset memoization as a safety precaution."
+  (setf (sp-state-last-syntax-ppss-point sp-state) nil
+        (sp-state-last-syntax-ppss-result sp-state) nil))
 
 (defun sp-remove-active-pair-overlay ()
   "Deactivate the active overlay.  See `sp--get-active-overlay'."

--- a/smartparens.el
+++ b/smartparens.el
@@ -1369,10 +1369,8 @@ sexp, otherwise the call may be very slow."
   (let ((p (or p (point))))
     (if (eq p (sp-state-last-syntax-ppss-point sp-state))
         (sp-state-last-syntax-ppss-result sp-state)
-      (let ((result (syntax-ppss p)))
-        (setf (sp-state-last-syntax-ppss-point sp-state) p
-              (sp-state-last-syntax-ppss-result sp-state) result)
-        result))))
+      (setf (sp-state-last-syntax-ppss-point sp-state) p
+            (sp-state-last-syntax-ppss-result sp-state) (syntax-ppss p)))))
 
 (defun sp-point-in-string (&optional p)
   "Return non-nil if point is inside string or documentation string.

--- a/smartparens.el
+++ b/smartparens.el
@@ -1369,6 +1369,9 @@ sexp, otherwise the call may be very slow."
   (let ((p (or p (point))))
     (if (eq p (sp-state-last-syntax-ppss-point sp-state))
         (sp-state-last-syntax-ppss-result sp-state)
+      ;; Add hook to reset memoization if necessary
+      (unless (sp-state-last-syntax-ppss-point sp-state)
+        (add-hook 'before-change-functions 'sp--reset-memoization t t))
       (setf (sp-state-last-syntax-ppss-point sp-state) p
             (sp-state-last-syntax-ppss-result sp-state) (syntax-ppss p)))))
 
@@ -2441,7 +2444,6 @@ should be highlighted."
   "Remove all pair overlays that doesn't have point inside them,
 are of zero length, or if point moved backwards."
   ;; if the point moved backwards, remove all overlays
-  (sp--reset-memoization)
   (if (and sp-cancel-autoskip-on-backward-movement
            (< (point) sp-previous-point))
       (dolist (o sp-pair-overlay-list) (sp--remove-overlay o))
@@ -2454,7 +2456,7 @@ are of zero length, or if point moved backwards."
   (when sp-pair-overlay-list
     (setq sp-previous-point (point))))
 
-(defun sp--reset-memoization ()
+(defun sp--reset-memoization (&rest ignored)
   "Reset memoization as a safety precaution."
   (setf (sp-state-last-syntax-ppss-point sp-state) nil
         (sp-state-last-syntax-ppss-result sp-state) nil))


### PR DESCRIPTION
These places are called many times each operation with the same point.
`syntax-ppss` can be slow in some modes, like elixir-mode.

## Before

```
+ flyspell-post-command-hook                                      694  64%
- command-execute                                                 291  26%
 - call-interactively                                             291  26%
  - funcall-interactively                                         291  26%
   - self-insert-command                                          275  25%
    - sp--post-self-insert-hook-handler                           261  24%
     - condition-case                                             261  24%
      - if                                                        261  24%
       - progn                                                    261  24%
        - if                                                      261  24%
         - let                                                    261  24%
          - let                                                   261  24%
           - cond                                                 261  24%
            - if                                                  259  24%
             - setq                                               259  24%
              - progn                                             259  24%
               - let                                              200  18%
                - cdr                                             200  18%
                 - sp--all-pairs-to-insert                        200  18%
                  - let                                           200  18%
                   - let                                          199  18%
                    - let                                         166  15%
                     - while                                      166  15%
                      - let                                       166  15%
                       - if                                       166  15%
                        - sp--do-action-p                         165  15%
                         - let*                                   133  12%
                          - if                                     81   7%
                           - sp-point-in-string                    81   7%
                            - condition-case                       78   7%
                             - progn                               78   7%
                              - save-excursion                     77   7%
                               - nth                               77   7%
                                + syntax-ppss                      73   6%
                          + cond                                   47   4%
                          + sp-get-pair                             3   0%
                          + sp--get-closing-regexp                  1   0%
                         + setq                                    32   2%
                        + progn                                     1   0%
                    + if                                           33   3%
               + sp-insert-pair                                    53   4%
               + sp-skip-closing-pair                               6   0%
            + sp--char-is-part-of-closing                           2   0%
    + flycheck-handle-change                                        8   0%
    + smie-blink-matching-open                                      2   0%
      jit-lock-after-change                                         2   0%
    + expand-abbrev                                                 1   0%
   + newline-and-indent                                             7   0%
   + evil-normal-state                                              5   0%
   + profiler-report                                                4   0%
+ redisplay_internal (C function)                                  28   2%
+ evil-escape-pre-command-hook                                     22   2%
+ ...                                                              20   1%
+ timer-event-handler                                              12   1%
+ sp--save-pre-command-state                                        5   0%
+ winner-save-old-configurations                                    3   0%
+ alchemist-company-filter                                          2   0%
+ company-post-command                                              1   0%
+ which-key--hide-popup                                             1   0%
```

## After

```
+ flyspell-post-command-hook                                      917  75%
- command-execute                                                 217  17%
 - call-interactively                                             217  17%
  - funcall-interactively                                         217  17%
   + newline-and-indent                                           202  16%
   + evil-normal-state                                              6   0%
   + profiler-report                                                4   0%
   + evil-open-below                                                3   0%
   - self-insert-command                                            1   0%
      jit-lock-after-change                                         1   0%
+ redisplay_internal (C function)                                  26   2%
+ ...                                                              13   1%
+ timer-event-handler                                              12   0%
+ winner-save-old-configurations                                    7   0%
+ evil-repeat-post-hook                                             4   0%
+ evil-escape-pre-command-hook                                      4   0%
+ evil-repeat-pre-hook                                              3   0%
+ alchemist-company-filter                                          3   0%
+ hl-paren-initiate-highlight                                       1   0%
```

These profiles were taken with https://github.com/Fuco1/smartparens/pull/628 included as well.