### PR TITLE
Prevent adding new whitespace when slurping forward/backward in OCaml and Latex

### DIFF
--- a/smartparens-config.el
+++ b/smartparens-config.el
@@ -116,6 +116,7 @@
   (eval-after-load it '(require 'smartparens-python)))
 (eval-after-load "scala-mode" '(require 'smartparens-scala))
 (eval-after-load "racket-mode" '(require 'smartparens-racket))
+(eval-after-load "tuareg-mode" '(require 'smartparens-ocaml))
 
 (provide 'smartparens-config)
 

--- a/smartparens-latex.el
+++ b/smartparens-latex.el
@@ -90,10 +90,32 @@ This predicate is only tested on \"insert\" action."
 (add-to-list 'sp-navigate-skip-match
              '((tex-mode plain-tex-mode latex-mode) . sp--backslash-skip-match))
 
+
+(defun sp-latex-pre-slurp-handler (id action context)
+  ;; If there was no space before or after, we shouldn't add on.
+  ;; Variable ok, next-thing are defined in
+  ;; `sp-forward-slurp-sexp' and `sp-backward-slurp-sexp'
+  (when (eq action 'slurp-forward)
+    (save-excursion
+      (when (and (sp-get ok (/= :len-in 0))
+                 (= (sp-get ok :end-suf) (sp-get next-thing :beg-prf)))
+        (goto-char (sp-get ok :end))
+        (when (looking-back " ")
+          (delete-char -1)))))
+  
+  (when (eq action 'slurp-backward)
+    (save-excursion
+      (when (and (sp-get ok (/= :len-in 0))
+                 (= (sp-get ok :beg-prf) (sp-get next-thing :end-suf)))
+        (goto-char (sp-get ok :beg))
+        (when (looking-at " ")
+          (delete-char 1))))))
+
 (sp-with-modes '(
                  tex-mode
                  plain-tex-mode
                  latex-mode
+                 LaTex-mode
                  )
   (sp-local-pair "`" "'"
                  :actions '(:rem autoskip)
@@ -148,6 +170,11 @@ This predicate is only tested on \"insert\" action."
   (sp-local-pair "\\lfloor" "\\rfloor" :post-handlers '(sp-latex-insert-spaces-inside-pair))
   (sp-local-pair "\\lceil" "\\rceil" :post-handlers '(sp-latex-insert-spaces-inside-pair))
   (sp-local-pair "\\langle" "\\rangle" :post-handlers '(sp-latex-insert-spaces-inside-pair))
+
+  ;; do not add more space when slurping
+  (sp-local-pair "{" "}" :pre-handlers '(sp-latex-pre-slurp-handler))
+  (sp-local-pair "(" ")" :pre-handlers '(sp-latex-pre-slurp-handler))
+  (sp-local-pair "[" "]" :pre-handlers '(sp-latex-pre-slurp-handler))
 
   ;; some common wrappings
   (sp-local-tag "\"" "``" "''" :actions '(wrap))

--- a/smartparens-ocaml.el
+++ b/smartparens-ocaml.el
@@ -1,0 +1,89 @@
+;;; smartparens-ocaml.el --- Additional configuration for Ocaml language
+
+;; Copyright (C) 2016 Ta Quang Trung
+
+;; Author: Ta Quang Trung <taquangtrungvn@gmail.com>
+;; Maintainer: Ta Quang Trung <taquangtrung@gmail.com>
+;; Created: 14 July 2016
+;; Keywords: abbrev convenience editing
+;; URL: https://github.com/taquangtrung/smartparens
+
+;; This file is not part of GNU Emacs.
+
+;;; License:
+
+;; This file is part of Smartparens.
+
+;; Smartparens is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; Smartparens is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with Smartparens.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This file provides some additional configuration for OCaml language.
+;; To use it, simply add:
+;;
+;; (require 'smartparens-ocaml)
+;;
+;; into your configuration.  You can use this in conjunction with the
+;; default config or your own configuration.
+;;
+;; If you have good ideas about what should be added please file an
+;; issue on the github tracker.
+;;
+;; For more info, see github readme at
+;; https://github.com/Fuco1/smartparens
+
+;;; Code:
+
+(require 'smartparens)
+
+;; This fixes slurping from adding space before or after "." if not needed
+;;
+;;   Forward-slurp:
+;;     UNWANTED: 
+;;       (foo) List.map  ~~> (foo List).map ~~ (foo List .map)
+;;     EXPECTED:
+;;       (foo) List.map  ~~> (foo List).map ~~ (foo List.map)
+;;
+;;   Backward-slurp:
+;;     UNWANTED: 
+;;       List.map (foo) ~~> List(.map foo) ~~> (List .map foo)
+;;     EXPECTED:
+;;       List.map (foo) ~~> List(.map foo) ~~> (List.map foo)
+
+(sp-with-modes 'tuareg-mode
+  (sp-local-pair "{" nil :pre-handlers '(sp-ocaml-pre-slurp-handler))
+  (sp-local-pair "(" nil :pre-handlers '(sp-ocaml-pre-slurp-handler))
+  (sp-local-pair "[" nil :pre-handlers '(sp-ocaml-pre-slurp-handler)))
+
+(defun sp-ocaml-pre-slurp-handler (id action context)
+  ;; If there was no space before or after, we shouldn't add on.
+  ;; Variable ok, next-thing are defined in `sp-forward-slurp-sexp'
+  (when (eq action 'slurp-forward)
+    (save-excursion
+      (when (and (sp-get ok (/= :len-in 0))
+                 (= (sp-get ok :end-suf) (sp-get next-thing :beg-prf)))
+        (goto-char (sp-get ok :end))
+        (when (looking-back " ")
+          (delete-char -1)))))
+  
+  (when (eq action 'slurp-backward)
+    (save-excursion
+      (when (and (sp-get ok (/= :len-in 0))
+                 (= (sp-get ok :beg-prf) (sp-get next-thing :end-suf)))
+        (goto-char (sp-get ok :beg))
+        (when (looking-at " ")
+          (delete-char 1))))))
+
+(provide 'smartparens-ocaml)
+;;; smartparens-ocaml.el ends here

--- a/test/smartparens-ocaml-test.el
+++ b/test/smartparens-ocaml-test.el
@@ -1,0 +1,36 @@
+(require 'ert)
+(require 'smartparens)
+
+(defun sp-test--ocaml-mode ()
+  (shut-up (tuareg-mode)))
+
+(ert-deftest sp-test-ocaml-forward-slurp-parenthesis-whitespace ()
+  "Ensure we don't add unwanted whitespace when slurping."
+  (sp-test-with-temp-buffer "(|foo) List.map"
+      (sp-test--ocaml-mode)
+    (sp-forward-slurp-sexp)
+    (should (equal (buffer-string) "(foo List.map)"))))
+
+(ert-deftest sp-test-ocaml-backward-slurp-parenthesis-whitespace ()
+  "Ensure we don't add unwanted whitespace when slurping."
+  (sp-test-with-temp-buffer "List.map (|foo)"
+      (sp-test--ocaml-mode)
+      (sp-backward-slurp-sexp)
+    (should (equal (buffer-string) "(List.map foo)"))))
+
+(ert-deftest sp-test-ocaml-forward-slurp-square-bracket-whitespace ()
+  "Ensure we don't add unwanted whitespace when slurping."
+  (sp-test-with-temp-buffer "[|foo] List.map"
+      (sp-test--ocaml-mode)
+    (sp-forward-slurp-sexp)
+    (should (equal (buffer-string) "[foo List.map]"))))
+
+(ert-deftest sp-test-ocaml-backward-slurp-square-bracket-whitespace ()
+  "Ensure we don't add unwanted whitespace when slurping."
+  (sp-test-with-temp-buffer "List.map [|foo]"
+      (sp-test--ocaml-mode)
+    (sp-forward-slurp-sexp)
+    (should (equal (buffer-string) "[foo List.map]"))))
+
+
+


### PR DESCRIPTION
Hi,

When using the excellent slurping feature, I encountered a problem in both OCaml and Latex. That is, a new whitespace is added when it is not supposed to:

For example: given a string `(foo) List.map`, I want to slurp forward to obtain `(foo List.map)`,
the current slurping forward adds a new space between `List.` and `map` as follow:

```
(foo) List.map  ~~> (foo List).map ~~> (foo List .map)
```

The unwanted space should be removed, so that the expected behaviour is:

```
(foo) List.map  ~~> (foo List).map ~~> (foo List.map)
```

In these commits, I fixed the this problem for both forward and backward slurping, in major modes for OCaml and Latex.

Please fell free to merge them into your repository, if they are necessary.

Bests,
Trung.
