### PR TITLE
Fix autoskipping closing chevrons in rust-mode

### DIFF
--- a/smartparens-rust.el
+++ b/smartparens-rust.el
@@ -62,15 +62,30 @@ If we return nil, ' should be used for character literals."
             (goto-char paren-pos)
             (looking-at "<"))))))
 
-(defun sp-rust-could-be-parameterized (&rest args)
-  "Return t if we could add a <T> in this position.
-If nil, the user is probably using < for something else."
-  (and (apply #'sp-in-code-p args)
-       (looking-back (rx (or letter (seq letter "<") (seq letter "::<"))))))
+(defun sp-rust-filter-angle-brackets (id action context)
+  "Return t if we should allow the ACTION in the current CONTEXT
+  for angle brackets."
+  (cond
+   ;; Disallow in format string after any character, since < is used to specify
+   ;; alignment
+   ((and (eq context 'string)
+         (looking-back (rx (seq alphanumeric "<")))) nil)
+
+   ;; Disallow when inserting in code in two situations: 1) when '<' is used for
+   ;; the comparison operators '<' and '<=', and 2) when writing a left shift
+   ;; '<<'.  In both cases, we assume the user will use a space before the
+   ;; opening bracket '<'.
+   ((and (eq context 'code)
+         (eq action 'insert)
+         (looking-back (rx (or (seq space "<")
+                               (seq space "<<"))))) nil)
+
+   ;; Otherwise, allow all actions
+   (t)))
 
 (sp-with-modes '(rust-mode)
   (sp-local-pair "'" "'" :unless '(sp-in-comment-p sp-in-string-p sp-in-rust-lifetime-context))
-  (sp-local-pair "<" ">" :when '(sp-rust-could-be-parameterized)))
+  (sp-local-pair "<" ">" :when '(sp-rust-filter-angle-brackets)))
 
 ;; Rust has no sexp suffices.  This fixes slurping
 ;; (|foo).bar -> (foo.bar)

--- a/test/smartparens-rust-test.el
+++ b/test/smartparens-rust-test.el
@@ -91,3 +91,19 @@ Regression test."
     (execute-kbd-macro "<")
     ;; We should have inserted a pair.
     (should (equal (buffer-string) "iterator.collect::<>"))))
+
+(ert-deftest sp-test-rust-pair-autoskip-closing-bracket ()
+  "Autoskip a matching >."
+  (sp-test-with-temp-buffer "E<T|>"
+      (rust-mode)
+    (execute-kbd-macro ">")
+    ;; We should have skipped the closing bracket.
+    (should (equal (buffer-string) "E<T>"))))
+
+(ert-deftest sp-test-rust-pair-insert-and-autoskip-closing-bracket ()
+  "Inserting multiples brackets and closing them."
+  (sp-test-with-temp-buffer "E|"
+      (rust-mode)
+    (execute-kbd-macro "<Rc<RefCell<T>>>")
+    ;; We should have inserted a pair without an extra chevron.
+    (should (equal (buffer-string) "E<Rc<RefCell<T>>>"))))


### PR DESCRIPTION
Before this commit, closing chevrons were not autoskipped.  Typing:

`T<` would result in the correct insertion of a matching closing
chevron: `T<|>`, but typing `>` would not result in `T<>|>`, not
skipping the closing chevron even with the `autoskip` action set on the
pair.

This was caused by the regexp in `sp-rust-could-be-parameterized` set as
a `when` filter for the local pair "<" ">".  This filter is called by
`sp--do-action-p` not only when inserting a chevron, but also when
determining if the closing chevron should be autoskipped.  In the
closing case, the regexp does not match, because at the moment this
check is done the code contains one extra chevron: `<T>|>`.

This commits adds a ">" alternative to the regexp so that filter returns
true when `sp--do-action-p` is called for the autoskip action on the
closing chevron.

Closes #642.