### PR TITLE
Match "`" with "`" in Clojure-related modes

### DIFF
--- a/smartparens-clojure.el
+++ b/smartparens-clojure.el
@@ -45,5 +45,12 @@
 (dolist (mode '(clojure-mode clojurescript-mode clojurec-mode cider-repl-mode))
   (add-to-list 'sp-sexp-prefix `(,mode regexp ,sp-clojure-prefix)))
 
+;; Match "`" with "`" in strings and comments
+(sp-with-modes sp-clojure-modes
+  (sp-local-pair "`" "`"
+                 :when '(sp-in-string-p
+                         sp-in-comment-p)
+                 :unless '(sp-lisp-invalid-hyperlink-p)))
+
 (provide 'smartparens-clojure)
 ;;; smartparens-clojure.el ends here

--- a/smartparens-config.el
+++ b/smartparens-config.el
@@ -65,7 +65,9 @@
 ;; lisp modes too
 (sp-with-modes sp-lisp-modes
   ;; disable ', it's the quote character!
-  (sp-local-pair "'" nil :actions nil)
+  (sp-local-pair "'" nil :actions nil))
+
+(sp-with-modes (cl-set-difference sp-lisp-modes sp-clojure-modes)
   ;; also only use the pseudo-quote inside strings where it serve as
   ;; hyperlink.
   (sp-local-pair "`" "'"

--- a/smartparens-config.el
+++ b/smartparens-config.el
@@ -67,7 +67,7 @@
   ;; disable ', it's the quote character!
   (sp-local-pair "'" nil :actions nil))
 
-(sp-with-modes (cl-set-difference sp-lisp-modes sp-clojure-modes)
+(sp-with-modes (-difference sp-lisp-modes sp-clojure-modes)
   ;; also only use the pseudo-quote inside strings where it serve as
   ;; hyperlink.
   (sp-local-pair "`" "'"

--- a/smartparens.el
+++ b/smartparens.el
@@ -516,7 +516,19 @@ Symbol is defined as a chunk of text recognized by
                            slime-repl-mode
                            stumpwm-mode
                            )
-  "List of Lisp modes."
+  "List of Lisp-related modes."
+  :type '(repeat symbol)
+  :group 'smartparens)
+
+(defcustom sp-clojure-modes '(
+                              cider-repl-mode
+                              clojure-mode
+                              clojurec-mode
+                              clojurescript-mode
+                              clojurex-mode
+                              inf-clojure-mode
+                              )
+  "List of Clojure-related modes."
   :type '(repeat symbol)
   :group 'smartparens)
 


### PR DESCRIPTION
Addresses #649 for Clojure-related modes.