### PR TITLE
added sp-mark-sexp analogous to mark-sexp

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -258,6 +258,7 @@ smartparens functions.")
                                   ("C-S-<backspace>" . sp-splice-sexp-killing-around)
                                   ("C-]" . sp-select-next-thing-exchange)
                                   ("C-M-]" . sp-select-next-thing)
+                                  ("C-M-SPC" . sp-mark-sexp)
                                   ("M-F" . sp-forward-symbol)
                                   ("M-B" . sp-backward-symbol)
                                   )
@@ -7968,6 +7969,32 @@ considered balanced expressions."
   (prog1
       (sp-select-previous-thing arg point)
     (exchange-point-and-mark)))
+
+(defun sp-mark-sexp (&optional arg allow-extend)
+  "Set mark ARG balanced expressions from point.
+The place mark goes is the same place \\[sp-forward-sexp] would
+move to with the same argument.
+Interactively, if this command is repeated
+or (in Transient Mark mode) if the mark is active,
+it marks the next ARG sexps after the ones already marked.
+This command assumes point is not in a string or comment."
+  (interactive "P\np")
+  (cond ((and allow-extend
+	      (or (and (eq last-command this-command) (mark t))
+		  (and transient-mark-mode mark-active)))
+	 (setq arg (if arg (prefix-numeric-value arg)
+		     (if (< (mark) (point)) -1 1)))
+	 (set-mark
+	  (save-excursion
+	    (goto-char (mark))
+	    (sp-forward-sexp arg)
+	    (point))))
+	(t
+	 (push-mark
+	  (save-excursion
+	    (sp-forward-sexp (prefix-numeric-value arg))
+	    (point))
+	  nil t))))
 
 (defun sp-delete-char (&optional arg)
   "Delete a character forward or move forward over a delimiter.


### PR DESCRIPTION
This adds a new command `sp-mark-sexp` that is analogous to Emacs's builtin `mark-sexp`, but uses smartparens notion of sexp. It also adds a key binding (`C-M-SPC`) for it to `sp-smartparens-bindings`. The chosen is key binding is one of Emacs's defaults for `mark-sexp` ---just like `sp-smartparens-bindings` uses Emacs's defaults for `forward-sexp`, `kill-sexp`, etc.