### PR TITLE
Fix backward-delete hang in comint when at end of last prompt

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -8228,7 +8228,9 @@ The return value is actually cons pair of opening and closing
 string delimiter enclosing this string."
   (setq pos (or pos (point)))
   (when (and (sp-point-in-string)
-             (save-excursion (forward-char) (not (sp-point-in-string)))
+             (save-excursion (if (eq (point-max) (point))
+                                 t
+                               (forward-char) (not (sp-point-in-string))))
              (save-excursion (backward-char) (not (sp-point-in-string))))
     (save-excursion
       (let* ((syntax (nth 3 (syntax-ppss pos)))

--- a/smartparens.el
+++ b/smartparens.el
@@ -8228,7 +8228,7 @@ The return value is actually cons pair of opening and closing
 string delimiter enclosing this string."
   (setq pos (or pos (point)))
   (when (and (sp-point-in-string)
-             (save-excursion (if (eq (point-max) (point))
+             (save-excursion (if (= (point-max) (point))
                                  t
                                (forward-char) (not (sp-point-in-string))))
              (save-excursion (backward-char) (not (sp-point-in-string))))


### PR DESCRIPTION
This should be a fix for #690. It at least stops the "end of buffer" problem... I'll have to keep testing to see if this has anything to do with the hanging that `C-g` was killing (that might be a jupyter ipython problem, because I haven't gotten it since switching to normal python repl).