### PR TITLE
Add GitHub issues template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Expected behavior
+
+
+
+## Actual behavior
+
+
+
+## Steps to reproduce the problem
+
+
+
+## Backtraces if necessary (`M-x toggle-debug-on-error`)
+
+
+
+## Environment & version information
+
+- `smartparens` version:
+- Active major-mode:
+- Emacs version (`M-x emacs-version`):
+- OS:


### PR DESCRIPTION
An issue template should cut down on the number of incomplete bug reports.