### PR TITLE
Replace kill-fn with wrapper that accounts for Evil Yank/Registers

### DIFF
--- a/Cask
+++ b/Cask
@@ -21,4 +21,5 @@
   (depends-on "ess")
   (depends-on "tuareg")
   (depends-on "scala-mode")
-  (depends-on "elixir-mode"))
+  (depends-on "elixir-mode")
+  (depends-on "evil"))

--- a/test/smartparens-evil-test.el
+++ b/test/smartparens-evil-test.el
@@ -1,0 +1,56 @@
+(require 'evil)
+
+(ert-deftest sp-test-evil-enabled-copy-sexp ()
+  "When `evil-mode' is enabled, copying sexp copies to 0 register."
+  (sp-test-with-temp-elisp-buffer "|(a b c)"
+    (evil-set-register ?0 nil)
+    (evil-mode)
+    (sp-kill-sexp 1 t)
+    (evil-mode -1)
+    (should (equal (buffer-string) (evil-get-register ?0)))))
+
+(ert-deftest sp-test-evil-disabled-copy-sexp ()
+  "When `evil-mode' is disabled, copying sexp doesn't modify 0 register."
+  (sp-test-with-temp-elisp-buffer "|(a b c)"
+    (evil-set-register ?0 nil)
+    (evil-mode -1)
+    (sp-kill-sexp 1 t)
+    (should (not (equal (buffer-string) (evil-get-register ?0))))))
+
+(ert-deftest sp-test-evil-enabled-copy-sexp-with-register ()
+  "When `evil-mode' is enabled, copying a sexp with register set will
+copy the sexp into that register."
+  (sp-test-with-temp-elisp-buffer "|(a b c)"
+    (evil-mode)
+    (setq evil-this-register ?a)
+    (sp-kill-sexp 1 t)
+    (evil-mode -1)
+    (should (equal (buffer-string) (evil-get-register ?a)))))
+
+(ert-deftest sp-test-evil-disabled-copy-sexp-with-register ()
+  "When `evil-mode' is disabled, copying a sexp with register set will not
+copy the sexp into that register."
+  (sp-test-with-temp-elisp-buffer "|(a b c)"
+    (evil-mode -1)
+    (setq evil-this-register ?c)
+    (sp-kill-sexp 1 t)
+    (should (not (equal (buffer-string) (evil-get-register ?c))))))
+
+(ert-deftest sp-test-evil-enabled-kill-sexp-with-register ()
+  "When `evil-mode' is enabled, killing a sexp with register set will
+copy the sexp into that register."
+  (sp-test-with-temp-elisp-buffer "|(a b c)"
+    (evil-mode)
+    (setq evil-this-register ?b)
+    (sp-kill-sexp 1 nil)
+    (evil-mode -1)
+    (should (equal "(a b c)" (evil-get-register ?b)))))
+
+(ert-deftest sp-test-evil-disabled-kill-sexp-with-register ()
+  "When `evil-mode' is disabled, killing a sexp with register set will not
+copy the sexp into that register."
+  (sp-test-with-temp-elisp-buffer "|(a b c)"
+    (evil-mode -1)
+    (setq evil-this-register ?d)
+    (sp-kill-sexp 1 nil)
+    (should (not (equal "(a b c)" (evil-get-register ?d))))))


### PR DESCRIPTION
Evil/Vim uses the 0 Register as the Yank Register. When yanking a
sexp, add the yanked text to the 0 Register too.

Added logic to add copied region to 0 Register like in Vim/Evil.

Added Register Prefix handling so that the yanked text goes into the
right place.

For example, this should be possible now.

"x (sp-copy-sexp)

:reg

0 Register and x register should contain the text that was copied.

https://github.com/Fuco1/smartparens/issues/724

Open to ideas on the Doc comment for the new function.