### PR TITLE
update local pairs for tuareg-mode and reason-mode

### DIFF
--- a/smartparens-ml.el
+++ b/smartparens-ml.el
@@ -1,12 +1,9 @@
 ;;; smartparens-ml.el --- Additional configuration for ML languages
 
-;; Copyright (C) 2016 Ta Quang Trung
-
-;; Author: Ta Quang Trung <taquangtrungvn@gmail.com>
-;; Maintainer: Ta Quang Trung <taquangtrung@gmail.com>
+;; Author: tddsg
 ;; Created: 14 July 2016
-;; Keywords: abbrev convenience editing
-;; URL: https://github.com/taquangtrung/smartparens
+;; Updated: 29 April 2017
+;; Keywords: smartparens, ML, ocaml, reason
 
 ;; This file is not part of GNU Emacs.
 

--- a/smartparens-ml.el
+++ b/smartparens-ml.el
@@ -47,5 +47,9 @@
 
 (require 'smartparens)
 
+;;; Local pairs for ML-family languages
+(sp-with-modes '(tuareg-mode) (sp-local-pair "(*" "*)" ))
+(sp-with-modes '(reason-mode) (sp-local-pair "/*" "*/" ))
+
 (provide 'smartparens-ml)
 ;;; smartparens-ml.el ends here


### PR DESCRIPTION
Hi,

I updated local pairs for 2 modes: tuareg-mode and reason-mode in the `smartparens-ml` package. This update will fix the issue described in https://github.com/Fuco1/smartparens/issues/730 since the pair `(* *)` will be automatically inserted when typing `(*`.

Could you double check and advise on the changes?

(Note that I change the description since I was using different github account to create the first version of `smartparens-ocaml`).

Thanks.

Note: this fixes #730 when merged.