### PR TITLE
Fix: sp-kill-hybrid-sexp breaks C-0 C-k

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -6346,7 +6346,7 @@ Examples:
                         (current-column)))
          (orig-column (current-column)))
     (cond
-     ((= arg 0) (kill-line))
+     ((= arg 0) (kill-line 0))
      ((and raw (= arg 16))
       (let ((hl (sp-get-hybrid-sexp)))
         (sp-get hl (kill-region :beg-prf :end-suf))))


### PR DESCRIPTION
## Expected behavior

[2.1.2 Killing Lines (Emacs Manual)](http://www.gnu.org/software/emacs/manual/html_node/emacs/Killing-by-Lines.html#Killing-by-Lines) :
>  When `C-k` is given a positive argument N, it kills N lines and the newlines that follow them (text on the current line before point is not killed).  With a negative argument `−N`, it kills N lines preceding the current line, together with the text on the current line before point. *`C-k` with an argument of zero kills the text before point on the current line.

`(kill-line &optional ARG)`:
> Kill the rest of the current line; if no nonblanks there, kill thru newline. With prefix argument ARG, kill that many lines from point. Negative arguments kill lines backward. With zero argument, kills the text before point on the current line.

`(sp-kill-hybrid-sexp ARG)` :
> [...] With ARG numeric prefix 0 (zero) just call `kill-line'. [...]

## Actual behavior
With `C-k` bound to `sp-kill-hybrid-sexp`, `C-0 C-k` kills text after point on current line.