### PR TITLE
Handle hungry-delete-mode.

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -8390,6 +8390,9 @@ Examples:
                 (setq n 0)
               (delete-char (length (match-string 0)))
               (setq n (1- n))))
+           ((bound-and-true-p hungry-delete-mode)
+            (hungry-delete-forward)
+            (setq n (1- n)))
            (t
             (delete-char 1)
             (setq n (1- n))))))
@@ -8472,6 +8475,9 @@ Examples:
                 (setq n 0)
               (delete-char (- (length (match-string 0))))
               (setq n (1- n))))
+           ((bound-and-true-p hungry-delete-mode)
+            (hungry-delete-backward 1)
+            (setq n (1- n)))
            (t
             (delete-char -1)
             (setq n (1- n))))))


### PR DESCRIPTION
This would address #705. Not really sure if this is the right way to go about this, but i think it wouldn't interfere with any smartparens operations, only setting the default to `hungry-delete-*` if hungry-delete-mode is on. 

Minimal testing seems to confirm this, though I'm sure I've only covered my biased subset of use cases.