### PR TITLE
Don't affect delete-selection-mode when SP is off

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -1393,7 +1393,7 @@ kill \"subwords\" when `subword-mode' is active."
 
 (defadvice delete-selection-pre-hook (around fix-sp-wrap activate)
   "Fix `sp-wrap' in `delete-selection-mode'."
-  (unless (sp-wrap--can-wrap-p)
+  (unless (and smartparens-mode (sp-wrap--can-wrap-p))
     ad-do-it))
 
 

--- a/test/smartparens-wrapping-test.el
+++ b/test/smartparens-wrapping-test.el
@@ -87,6 +87,32 @@
     (sp-test-wrapping "|aM" "[[" "[[|a]]")
     (sp-test-wrapping "Ma|" "[[" "[[a]]|")))
 
+(ert-deftest sp-test-wrap-in-delete-selection-mode nil
+  (sp-test-with-temp-elisp-buffer "|fooM"
+    (delete-selection-mode 1)
+    ;; Inserting a character that pairs should wrap instead of
+    ;; replacing the selection.
+    (execute-kbd-macro "(")
+    (sp-buffer-equals "(|fooM)")))
+
+(ert-deftest sp-test-delete-selection-mode-still-works nil
+  "Test that `delete-selection-pre-hook' still works despite our advice on it."
+  (sp-test-with-temp-elisp-buffer "|fooM"
+    (delete-selection-mode 1)
+    ;; Inserting a character that does not pair should replace the
+    ;; selection when delete-selection-mode is on.
+    (execute-kbd-macro "x")
+    (sp-buffer-equals "x|")))
+
+;; #763
+(ert-deftest sp-test-delete-selection-mode-after-turning-sp-off nil
+  "Don't inhibit `delete-selection-mode' after smartparens is turned off."
+  (sp-test-with-temp-elisp-buffer "|fooM"
+    (delete-selection-mode 1)
+    (smartparens-mode -1)
+    (execute-kbd-macro "(")
+    (sp-buffer-equals "(|")))
+
 (defun sp-test-wrapping-latex (initial keys result)
   (sp-test-with-temp-buffer initial
       (latex-mode)


### PR DESCRIPTION
When `delete-selection-mode` is on, typing a character with an active region will replace the region with the typed character.  However, smartparens advises `delete-selection-pre-hook` to inhibit this behavior when the typed character is part of a pair, as smartparens wants to wrap the region rather than replace it.

However, if you turn smartparens on and then back off in a buffer where `delete-selection-mode` is also on, this advice would prevent `delete-selection-pre-hook` from replacing the selection even though smartparens is not on, and therefore the region would be neither deleted nor wrapped.  This commit makes it so that the smartparens advice never affects `delete-selection-pre-hook` unless smartparens-mode is turned on.

Fixes #763.