### PR TITLE
Fix handling of commas during slurp and barf in elixir-mode

### DIFF
--- a/smartparens-elixir.el
+++ b/smartparens-elixir.el
@@ -27,6 +27,9 @@
 
 (require 'smartparens)
 
+(--each '(elixir-mode)
+  (add-to-list 'sp-sexp-suffix (list it 'regexp "")))
+
 (defun sp-elixir-def-p (id)
   "Return non-nil if the \"do\" keyword is part of definition.
 

--- a/test/smartparens-elixir-test.el
+++ b/test/smartparens-elixir-test.el
@@ -115,3 +115,31 @@ end"))
 (ert-deftest sp-test-elixir-case-block-insertion ()
   (sp-test-insertion-elixir "|" "case " "case | do
 end"))
+
+(ert-deftest sp-test-elixir-forward-slurp ()
+  "Ensure that commas are handled properly when slurping forward"
+  (sp-test-with-temp-buffer "[1, [|2], :a]"
+      (elixir-mode)
+    (sp-forward-slurp-sexp)
+    (should (equal (buffer-string) "[1, [2, :a]]"))))
+
+(ert-deftest sp-test-elixir-backward-slurp ()
+  "Ensure that commas are handled properly when slurping backward"
+  (sp-test-with-temp-buffer "[1,[|2],:a]"
+      (elixir-mode)
+    (sp-backward-slurp-sexp)
+    (should (equal (buffer-string) "[[1,2],:a]"))))
+
+(ert-deftest sp-test-elixir-forward-barf ()
+  "Ensure that commas are handled properly when barfing forward"
+  (sp-test-with-temp-buffer "{1, {2,|:a}}"
+      (elixir-mode)
+    (sp-forward-barf-sexp)
+    (should (equal (buffer-string) "{1, {2},:a}"))))
+
+(ert-deftest sp-test-elixir-backward-barf ()
+  "Ensure that commas are handled properly when barfing backward"
+  (sp-test-with-temp-buffer "{1,{2,|:a}}"
+      (elixir-mode)
+    (sp-backward-barf-sexp)
+    (should (equal (buffer-string) "{1,2,{:a}}"))))


### PR DESCRIPTION
Current configuration of smartparens for `elixir-mode` has problems with handling commas (`,`) during slurping and barfing. 
Example: 
![](http://i.imgur.com/ohSnw6f.gif)

I have stolen the solution from `scala-mode` which had the similar problem:
![](http://i.imgur.com/ywZaFvT.gif)