### PR TITLE
In rust-mode, allow typing match branches (=>) in strict mode

### DIFF
--- a/smartparens-rust.el
+++ b/smartparens-rust.el
@@ -78,6 +78,8 @@ ARGS."
    ((eq context 'code)
     (let ((on-fn-return-type
            (looking-back (rx "->") nil))
+          (on-match-branch
+           (looking-back (rx "=>") nil))
           (on-comparison
            (looking-back (rx (or
                               (seq space "<")
@@ -89,18 +91,18 @@ ARGS."
        ;; Only insert a matching > if we're not looking at a
        ;; comparison.
        ((eq action 'insert)
-        (and (not on-comparison) (not on-fn-return-type)))
+        (and (not on-comparison) (not on-fn-return-type) (not on-match-branch)))
        ;; Always allow wrapping in a pair if the region is active.
        ((eq action 'wrap)
-        t)
+        (not on-match-branch))
        ;; When pressing >, autoskip if we're not looking at a
        ;; comparison.
        ((eq action 'autoskip)
-        (and (not on-comparison) (not on-fn-return-type)))
+        (and (not on-comparison) (not on-fn-return-type) (not on-match-branch)))
        ;; Allow navigation, highlighting and strictness checks if it's
        ;; not a comparison.
        ((eq action 'navigate)
-        (and (not on-comparison) (not on-fn-return-type))))))))
+        (and (not on-comparison) (not on-fn-return-type) (not on-match-branch))))))))
 
 (sp-with-modes '(rust-mode)
   (sp-local-pair "'" "'"

--- a/test/smartparens-rust-test.el
+++ b/test/smartparens-rust-test.el
@@ -131,3 +131,10 @@ fn bar(x: u64) -> bool {
     (execute-kbd-macro "<Rc<RefCell<T>>>")
     ;; We should have inserted a pair without an extra chevron.
     (should (equal (buffer-string) "E<Rc<RefCell<T>>>"))))
+
+(ert-deftest sp-test-rust-insert-match-branch ()
+  "Inserting a match branch with a rocket (=>) operator."
+  (sp-test-with-temp-buffer "match Some(1) { Some(n) =| }"
+                            (rust-mode)
+                            (execute-kbd-macro "> n")
+                            (should (equal (buffer-string) "match Some(1) { Some(n) => n }"))))


### PR DESCRIPTION
I'm writing a bunch of rust lately, and have run into a problem where I couldn't insert `=>` in strict mode. Soooo, this pull request adds a test & adjusts the pair logic to correctly work when `=>` is inserted in rust.

Hope this is acceptable - it looks like all rust tests are passing with this change (: