### PR TITLE
Add `turn-off-smartparens-strict-mode`

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -705,6 +705,12 @@ after the smartparens indicator in the mode list."
                    (eq (get major-mode 'mode-class) 'special)))
     (smartparens-strict-mode 1)))
 
+;;;###autoload
+(defun turn-off-smartparens-strict-mode ()
+  "Turn off `smartparens-strict-mode'."
+  (interactive)
+  (smartparens-strict-mode -1))
+
 (defun sp--init ()
   "Initialize the buffer local smartparens state.
 


### PR DESCRIPTION
There's an asymmetry in having `turn-on-smartparens-strict-mode` without having a corresponding `turn-off`.