### PR TITLE
Improve performance of delete-selection-pre-hook when no region is active

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -1398,7 +1398,9 @@ kill \"subwords\" when `subword-mode' is active."
 
 (defadvice delete-selection-pre-hook (around fix-sp-wrap activate)
   "Fix `sp-wrap' in `delete-selection-mode'."
-  (unless (and smartparens-mode (sp-wrap--can-wrap-p))
+  (unless (and smartparens-mode
+               (sp--delete-selection-p) (use-region-p) (not buffer-read-only)
+               (sp-wrap--can-wrap-p))
     ad-do-it))
 
 


### PR DESCRIPTION
This is a small change to the ```delete-selection-pre-hook``` advice to avoid unnecessary computations.

I noticed sluggish responses when moving around some buffers; profiling revealed the advice to ```delete-selection-pre-hook``` to be the culprit. In particular, it repeatedly called ```sp-wrap--can-wrap-p```, which ate a large fraction of CPU time. With this patch, ```sp-wrap--can-wrap-p``` is only called when there actually is an active region. The additional condition is directly taken from ```delete-selection-pre-hook```; it is used there to decide whether to do something. With this small change, the problem of sluggish response times went away.