### PR TITLE
Narrow in `sp-region-ok-p` after doing syntax checks

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -8900,8 +8900,8 @@ ordered, that is [(]) is correct even though it is not logically
 properly balanced."
   (save-excursion
     (save-restriction
-      (narrow-to-region start end)
       (when (eq (sp-point-in-string start) (sp-point-in-string end))
+        (narrow-to-region start end)
         (let ((regex (sp--get-allowed-regexp (-difference sp-pair-list (sp--get-allowed-pair-list)))))
           (goto-char (point-min))
           (while (or (prog1 (sp-forward-sexp)


### PR DESCRIPTION
This ensures `sp-point-in-string` returns correctly when invoked from
`evil-smartparens` etc - see https://github.com/expez/evil-smartparens/issues/42