### PR TITLE
Make sp-kill-whole-line remove the newline like kill-whole-line

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -6679,10 +6679,9 @@ Examples:
   (interactive)
   (beginning-of-line)
   (sp-kill-hybrid-sexp nil)
-  (let ((line-start (save-excursion (beginning-of-line) (point)))
-        (buffer-end (save-excursion (end-of-buffer) (point))))
+  (let ((empty-last-line (save-excursion (beginning-of-line) (eobp))))
     ;; We can't kill the line if it is empty and the last line
-    (when (and (sp-point-in-blank-line) (/= line-start buffer-end))
+    (when (and (sp-point-in-blank-line) (not empty-last-line))
       (kill-whole-line))))
 
 (defun sp--transpose-objects (first second)

--- a/smartparens.el
+++ b/smartparens.el
@@ -6679,8 +6679,11 @@ Examples:
   (interactive)
   (beginning-of-line)
   (sp-kill-hybrid-sexp nil)
-  (when (sp-point-in-blank-line)
-    (kill-whole-line)))
+  (let ((line-start (save-excursion (beginning-of-line) (point)))
+        (buffer-end (save-excursion (end-of-buffer) (point))))
+    ;; We can't kill the line if it is empty and the last line
+    (when (and (sp-point-in-blank-line) (/= line-start buffer-end))
+      (kill-whole-line))))
 
 (defun sp--transpose-objects (first second)
   "Transpose FIRST and SECOND object while preserving the

--- a/smartparens.el
+++ b/smartparens.el
@@ -6679,7 +6679,8 @@ Examples:
   (interactive)
   (beginning-of-line)
   (sp-kill-hybrid-sexp nil)
-  (sp-kill-hybrid-sexp nil))
+  (when (sp-point-in-blank-line)
+    (delete-char 1)))
 
 (defun sp--transpose-objects (first second)
   "Transpose FIRST and SECOND object while preserving the

--- a/smartparens.el
+++ b/smartparens.el
@@ -6678,6 +6678,7 @@ Examples:
     (some |long sexp))  ->    |)"
   (interactive)
   (beginning-of-line)
+  (sp-kill-hybrid-sexp nil)
   (sp-kill-hybrid-sexp nil))
 
 (defun sp--transpose-objects (first second)

--- a/smartparens.el
+++ b/smartparens.el
@@ -6680,7 +6680,7 @@ Examples:
   (beginning-of-line)
   (sp-kill-hybrid-sexp nil)
   (when (sp-point-in-blank-line)
-    (delete-char 1)))
+    (kill-whole-line)))
 
 (defun sp--transpose-objects (first second)
   "Transpose FIRST and SECOND object while preserving the

--- a/test/smartparens-commands-test.el
+++ b/test/smartparens-commands-test.el
@@ -679,6 +679,7 @@ be."
 
 (sp-test-command sp-kill-whole-line
   ((nil
+    ("(progn (some |long sexp))" "|")
     ("(progn (some |long sexp))\n" "|")
     ("(progn\n  (some |long sexp))" "(progn\n  |)")
     ("(progn\n | (some\nlong\nsexp))" "(progn\n  |)")

--- a/test/smartparens-commands-test.el
+++ b/test/smartparens-commands-test.el
@@ -679,10 +679,11 @@ be."
 
 (sp-test-command sp-kill-whole-line
   ((nil
-    ("(progn (some |long sexp))" "|")
+    ("(progn (some |long sexp))\n" "|")
     ("(progn\n  (some |long sexp))" "(progn\n  |)")
     ("(progn\n | (some\nlong\nsexp))" "(progn\n  |)")
-    ("(progn\n  (so|me\nlong\nsexp))" "(progn\n  |)"))))
+    ("(progn\n  (so|me\nlong\nsexp))" "(progn\n  |)")
+    ("(progn\n  (line|1)\n  (line2))" "(progn\n|  (line2))"))))
 
 (sp-test-command sp-transpose-sexp
   ((nil

--- a/test/smartparens-commands-test.el
+++ b/test/smartparens-commands-test.el
@@ -684,7 +684,8 @@ be."
     ("(progn\n  (some |long sexp))" "(progn\n  |)")
     ("(progn\n | (some\nlong\nsexp))" "(progn\n  |)")
     ("(progn\n  (so|me\nlong\nsexp))" "(progn\n  |)")
-    ("(progn\n  (line|1)\n  (line2))" "(progn\n|  (line2))"))))
+    ("(progn\n  (line|1)\n  (line2))" "(progn\n|  (line2))")
+    ("  (indented |line)" "|"))))
 
 (sp-test-command sp-transpose-sexp
   ((nil


### PR DESCRIPTION
Currently `sp-kill-whole-line` essentially does a balanced <kbd>C-a C-k </kbd> (delete contents of line up to newline) however kill-whole-line acts more like <kbd> C-a C-k C-k </kbd> (delete contents of line including newline.

I think the smartparens commands with similar names should try to mimic the builtin emacs commands. However this change will probably break the workflow of people who depended on the <kbd> C-a C-k </kbd> behaviour.