### PR TITLE
Add sp-forward-hybrid-sexp and sp-backward-hybrid-sexp

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -5896,6 +5896,31 @@ is the last child of the enclosing sexp as defined by
                  (sp-backward-sexp)))))))
       re)))
 
+;; TODO: skip empty lines?
+(defun sp-forward-hybrid-sexp (&optional arg)
+  "Move forward over one hybrid sexp.
+
+See `sp-get-hybrid-sexp'."
+  (interactive "^p")
+  (-when-let (sexp (sp-get-hybrid-sexp))
+    (sp-get sexp
+      ;; if we did not move forward at all, let's try one more time
+      (if (< (point) :end-suf)
+          (sp-get sexp (goto-char :end-suf))
+        (when (= (forward-line 1) 0)
+          (-when-let (sexp2 (sp-get-hybrid-sexp))
+            (sp-get sexp2 (goto-char :end-suf))))))))
+
+(defun sp-backward-hybrid-sexp (&optional arg)
+  "Move backward over one hybrid sexp.
+
+See `sp-get-hybrid-sexp'."
+  (interactive "^p")
+  (-when-let (sexp (save-excursion
+                     (when (sp-backward-sexp)
+                       (sp-get-hybrid-sexp))))
+    (sp-get sexp (goto-char :beg-prf))))
+
 (defun sp--raw-argument-p (arg)
   "Return t if ARG represents raw argument, that is a non-empty list."
   (and (listp arg) (car arg)))


### PR DESCRIPTION
This is like moving by lines except it jumps over the "logical lines", that is one statement spread over multiple lines.  So in case we have something like

```php
|$credentials = $this->facade->create([
    'email' => 'bill@salescompany.xy',
    'name' => 'Bill',
    'password' => 'QWErty098',
    'projectId' => $this->resourceProvider->getValidProject()->getId(),
    'role' => Security\Roles::AGENT,
    'salescode' => 'TST0002',
], $admin);
```

normal navigation by sexp would land after `$credentials`, then over the method chain and finally only at the `(` it would jump to the end of the statement.  The hybrid sexp recognizes this entire thing as one entity and jumps to the end of the logical line, which is at the semicolon.

Note that this is *NOT ALWAYS* just "go to semicolon", it would work without semicolon just as fine.  Also inside the `[...]` array the end of hybrid sexp is at the ending `]` not at the end of the statement.  In other words, it should recognize any statement spread over multiple line which is still one "node" in the AST.

Super cool!
