### PR TITLE
Do not insert elixir bracketed keywords in strings.

### DIFF
--- a/smartparens-elixir.el
+++ b/smartparens-elixir.el
@@ -101,30 +101,30 @@ ID, ACTION, CONTEXT."
   (sp-local-pair "def" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
                  :post-handlers '(sp-elixir-do-block-post-handler)
-                 :unless '(sp-in-comment-p))
+                 :unless '(sp-in-comment-p sp-in-string-p))
   (sp-local-pair "defp" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
                  :post-handlers '(sp-elixir-do-block-post-handler)
-                 :unless '(sp-in-comment-p))
+                 :unless '(sp-in-comment-p sp-in-string-p))
   (sp-local-pair "defmodule" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
                  :post-handlers '(sp-elixir-do-block-post-handler)
-                 :unless '(sp-in-comment-p))
+                 :unless '(sp-in-comment-p sp-in-string-p))
   (sp-local-pair "fn" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
                  :post-handlers '("| "))
   (sp-local-pair "if" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
                  :post-handlers '(sp-elixir-do-block-post-handler)
-                 :unless '(sp-in-comment-p))
+                 :unless '(sp-in-comment-p sp-in-string-p))
   (sp-local-pair "unless" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
                  :post-handlers '(sp-elixir-do-block-post-handler)
-                 :unless '(sp-in-comment-p))
+                 :unless '(sp-in-comment-p sp-in-string-p))
   (sp-local-pair "case" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
                  :post-handlers '(sp-elixir-do-block-post-handler)
-                 :unless '(sp-in-comment-p))
+                 :unless '(sp-in-comment-p sp-in-string-p))
   (sp-local-pair "receive" "end"
                  :when '(("RET" "<evil-ret>"))
                  :post-handlers '(sp-elixir-empty-do-block-post-handler))

--- a/test/smartparens-elixir-test.el
+++ b/test/smartparens-elixir-test.el
@@ -119,6 +119,9 @@ end"))
 (ert-deftest sp-test-elixir-if-block-insertion-in-comment ()
   (sp-test-insertion-elixir "# comment |" "if " "# comment if |"))
 
+(ert-deftest sp-test-elixir-if-block-insertion-in-string ()
+  (sp-test-insertion-elixir "\"a string |" "if " "\"a string if |"))
+
 (ert-deftest sp-test-elixir-forward-slurp ()
   "Ensure that commas are handled properly when slurping forward"
   (sp-test-with-temp-buffer "[1, [|2], :a]"


### PR DESCRIPTION
Similar to 1bf46316 this prevents smartparens from inserting a `do`,`end` pair
when you type one of it's keywords inside a string.