### PR TITLE
Support crystal

### DIFF
--- a/Cask
+++ b/Cask
@@ -27,4 +27,5 @@
   (depends-on "haskell-mode")
   (depends-on "markdown-mode")
   (depends-on "hungry-delete")
-  (depends-on "evil"))
+  (depends-on "evil")
+  (depends-on "crystal-mode"))

--- a/smartparens-crystal.el
+++ b/smartparens-crystal.el
@@ -8,7 +8,7 @@
 ;; Keywords: abbrev convenience editing
 ;; URL: https://github.com/Fuco1/smartparens
 
-;; Based on on smartparens-ruby.el
+;; Based on smartparens-ruby.el
 
 ;; This file is not part of GNU Emacs.
 
@@ -49,6 +49,7 @@
 ;;; Code:
 
 (require 'smartparens)
+(require 'smartparens-ruby)
 
 (declare-function crystal-forward-sexp "crystal")
 (declare-function crystal-backward-sexp "crystal")
@@ -62,142 +63,6 @@
   "Wrapper for `crystal-backward-sexp'."
   (interactive)
   (crystal-backward-sexp))
-
-(defun sp-crystal-maybe-one-space ()
-  "Turn whitespace around point to just one space."
-  (while (looking-back " " nil) (backward-char))
-  (when (or (looking-at-p " ")
-            (looking-at-p "}")
-            (looking-back "{" nil)
-            (and (looking-at-p "\\sw")
-                 (looking-back ":" nil)))
-    (save-excursion (just-one-space)))
-  (when (and (not (looking-back "^.?" nil))
-             (save-excursion
-               (backward-char 2)
-               (or (looking-at-p ".[^:] [.([,;]")
-                   (looking-at-p ".. ::")
-                   (looking-at-p ".[.@$] ")
-                   (looking-at-p ":: "))))
-    (delete-char 1)))
-
-(defun sp-crystal-delete-indentation (&optional arg)
-  "Better way of joining crystal lines.
-
-ARG is how many indentation to delete."
-  (delete-indentation arg)
-  (sp-crystal-maybe-one-space))
-
-(defun sp-crystal-block-post-handler (id action context)
-  "Handler for crystal block-like insertions.
-ID, ACTION, CONTEXT."
-  (when (equal action 'insert)
-    (save-excursion
-      (newline)
-      (indent-according-to-mode))
-    (indent-according-to-mode))
-  (sp-crystal-post-handler id action context))
-
-(defun sp-crystal-def-post-handler (id action context)
-  "Handler for crystal def-like insertions.
-ID, ACTION, CONTEXT."
-  (when (equal action 'insert)
-    (save-excursion
-      (insert "x")
-      (newline)
-      (indent-according-to-mode))
-    (delete-char 1))
-  (sp-crystal-post-handler id action context))
-
-(defun sp-crystal-post-handler (_id action _context)
-  "Crystal post handler.
-ID, ACTION, CONTEXT."
-  (-let (((&plist :arg arg :enc enc) sp-handler-context))
-    (when (equal action 'barf-backward)
-      (sp-crystal-delete-indentation 1)
-      (indent-according-to-mode)
-      (save-excursion
-        (sp-backward-sexp) ; move to begining of current sexp
-        (sp-backward-sexp arg)
-        (sp-crystal-maybe-one-space)))
-
-    (when (equal action 'barf-forward)
-      (sp-get enc
-        (let ((beg-line (line-number-at-pos :beg-in))
-              (end-line (line-number-at-pos :end-in)))
-          (sp-forward-sexp arg)
-          (sp-crystal-maybe-one-space)
-          (when (not (= (line-number-at-pos) beg-line))
-            (sp-crystal-delete-indentation -1))
-          (indent-according-to-mode))))))
-
-(defun sp-crystal-pre-handler (_id action _context)
-  "Handler for crystal slurp and barf.
-ID, ACTION, CONTEXT."
-  (let ((enc (plist-get sp-handler-context :enc)))
-    (sp-get enc
-      (let ((beg-line (line-number-at-pos :beg-in))
-            (end-line (line-number-at-pos :end-in)))
-
-        (when (equal action 'slurp-backward)
-          (save-excursion
-            (sp-forward-sexp)
-            (when (looking-at-p ";") (forward-char))
-            (sp-crystal-maybe-one-space)
-            (when (not (= (line-number-at-pos) end-line))
-              (sp-crystal-delete-indentation -1)))
-          (when (looking-at-p "::")
-            (while (and (looking-back "\\sw" nil)
-                        (--when-let (sp-get-symbol t)
-                          (sp-get it (goto-char :beg-prf))))))
-          (while (thing-at-point-looking-at "\\.[[:blank:]\n]*")
-            (sp-backward-sexp))
-          (when (looking-back "[@$:&?!]" nil)
-            (backward-char)
-            (when (looking-back "[@&:]" nil)
-              (backward-char)))
-          (just-one-space)
-          (save-excursion
-            (if (= (line-number-at-pos) end-line)
-                (insert " ")
-              (newline))))
-
-        (when (equal action 'barf-backward)
-          ;; Barf whole method chains
-          (while (thing-at-point-looking-at "[(.:[][\n[:blank:]]*")
-            (sp-forward-sexp))
-          (if (looking-at-p " *$")
-              (newline)
-            (save-excursion (newline))))
-
-        (when (equal action 'slurp-forward)
-          (save-excursion
-            (sp-backward-sexp)
-            (when (looking-back "\." nil) (backward-char))
-            (sp-crystal-maybe-one-space)
-            (when (not (= (line-number-at-pos) beg-line))
-              (if (thing-at-point-looking-at "\\.[[:blank:]\n]*")
-                  (progn
-                    (forward-symbol -1)
-                    (sp-crystal-delete-indentation -1))
-                (sp-crystal-delete-indentation))))
-          (while (looking-at-p "::") (sp-forward-symbol))
-          (when (looking-at-p "[?!;]") (forward-char))
-          (if (= (line-number-at-pos) beg-line)
-              (insert " ")
-            (newline)))
-
-        (when (equal action 'barf-forward)
-          (when (looking-back "\\." nil) (backward-char))
-          (when (looking-at-p "::")
-            (while (and (looking-back "\\sw" nil)
-                        (--when-let (sp-get-symbol t)
-                          (sp-get it (goto-char :beg-prf))))))
-          (if (= (line-number-at-pos) end-line)
-              (insert " ")
-            (if (looking-back "^[[:blank:]]*" nil)
-                (save-excursion (newline))
-              (newline))))))))
 
 (defun sp-crystal-inline-p (id)
   "Test if ID is inline."
@@ -217,203 +82,145 @@ ID, ACTION, CONTEXT."
               (sp-crystal-forward-sexp)
               (looking-at-p (concat "[^[:blank:]]* *" id))))))))
 
-(defun sp-crystal-method-p (id)
-  "Test if ID is a method."
-  (save-excursion
-    (when (looking-back id nil)
-      (backward-word))
-    (and (looking-at-p id)
-         (or
-          ;; fix for def_foo
-          (looking-at-p (concat id "[_?!:]"))
-          ;; fix for foo_def
-          (looking-back "[_:@$.]" nil)
-          ;; fix for def for; end
-          (looking-back "def \\|class \\|module " nil)
-          ;; Check if multiline method call
-          ;; But beware of comments!
-          (and (looking-back "\\.[[:blank:]\n]*" nil)
-               (not (save-excursion
-                      (search-backward ".")
-                      (sp-point-in-comment))))))))
-
 (defun sp-crystal-skip-inline-match-p (ms _mb _me)
   "If non-nil, skip inline match.
 MS, MB, ME."
-  (or (sp-crystal-method-p ms)
+  (or (sp-ruby-method-p ms)
       (sp-crystal-inline-p ms)))
-
-(defun sp-crystal-skip-method-p (ms _mb _me)
-  "If non-nil, skip method.
-MS, MB, ME."
-  (sp-crystal-method-p ms))
-
-(defun sp-crystal-in-string-or-word-p (id action context)
-  "Test if point is inside string or word.
-ID, ACTION, CONTEXT."
-  (or (sp-in-string-p id action context)
-      (and (looking-back id nil)
-           (not (looking-back (sp--strict-regexp-quote id) nil)))
-      (sp-crystal-method-p id)))
 
 (defun sp-crystal-in-string-word-or-inline-p (id action context)
   "Test if point is inside string, word or inline.
 ID, ACTION, CONTEXT."
-  (or (sp-crystal-in-string-or-word-p id action context)
+  (or (sp-ruby-in-string-or-word-p id action context)
       (and (looking-back id nil)
            (sp-crystal-inline-p id))))
 
-(defun sp-crystal-pre-pipe-handler (id action _context)
-  "Crystal pipe handler.
-ID, ACTION, CONTEXT."
-  (when (equal action 'insert)
-    (save-excursion
-      (just-one-space))
-    (save-excursion
-      (search-backward id)
-      (just-one-space))))
-
-(defun sp-crystal-should-insert-pipe-close (id action _context)
-  "Test whether to insert the closing pipe for a lambda-binding pipe pair.
-ID, ACTION, CONTEXT"
-  (if (eq action 'insert)
-      (thing-at-point-looking-at
-       (rx-to-string `(and (or "do" "{") (* space) ,id)))
-    t))
-
-(defun sp--crystal-skip-match (ms me mb)
-  "Crystal skip match.
-MS, ME, MB."
-  (when (string= ms "end")
-    (or (sp-in-string-p ms me mb)
-        (sp-crystal-method-p "end"))))
-
 (add-to-list 'sp-navigate-skip-match
-             '((crystal-mode motion-mode) . sp--crystal-skip-match))
+             '((crystal-mode) . sp--ruby-skip-match))
 
-(dolist (mode '(crystal-mode motion-mode))
+(dolist (mode '(crystal-mode))
   (add-to-list 'sp-sexp-suffix `(,mode syntax "")))
 
-(sp-with-modes '(crystal-mode motion-mode)
+(sp-with-modes 'crystal-mode
   (sp-local-pair "do" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :unless '(sp-ruby-in-string-or-word-p sp-in-comment-p)
                  :actions '(insert navigate)
-                 :pre-handlers '(sp-crystal-pre-handler)
-                 :post-handlers '(sp-crystal-block-post-handler)
-                 :skip-match 'sp-crystal-skip-method-p
+                 :pre-handlers '(sp-ruby-pre-handler)
+                 :post-handlers '(sp-ruby-block-post-handler)
+                 :skip-match 'sp-ruby-skip-method-p
                  :suffix "")
 
   (sp-local-pair "{" "}"
-                 :pre-handlers '(sp-crystal-pre-handler)
-                 :post-handlers '(sp-crystal-post-handler)
+                 :pre-handlers '(sp-ruby-pre-handler)
+                 :post-handlers '(sp-ruby-post-handler)
                  :suffix "")
 
   (sp-local-pair "begin" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :unless '(sp-ruby-in-string-or-word-p sp-in-comment-p)
                  :actions '(insert navigate)
-                 :pre-handlers '(sp-crystal-pre-handler)
-                 :post-handlers '(sp-crystal-block-post-handler)
-                 :skip-match 'sp-crystal-skip-method-p
+                 :pre-handlers '(sp-ruby-pre-handler)
+                 :post-handlers '(sp-ruby-block-post-handler)
+                 :skip-match 'sp-ruby-skip-method-p
                  :suffix "")
 
   (sp-local-pair "def" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :unless '(sp-ruby-in-string-or-word-p sp-in-comment-p)
                  :actions '(insert navigate)
-                 :pre-handlers '(sp-crystal-pre-handler)
-                 :post-handlers '(sp-crystal-def-post-handler)
-                 :skip-match 'sp-crystal-skip-method-p
+                 :pre-handlers '(sp-ruby-pre-handler)
+                 :post-handlers '(sp-ruby-def-post-handler)
+                 :skip-match 'sp-ruby-skip-method-p
                  :suffix "")
 
   (sp-local-pair "class" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :unless '(sp-ruby-in-string-or-word-p sp-in-comment-p)
                  :actions '(insert navigate)
-                 :pre-handlers '(sp-crystal-pre-handler)
-                 :post-handlers '(sp-crystal-def-post-handler)
-                 :skip-match 'sp-crystal-skip-method-p
+                 :pre-handlers '(sp-ruby-pre-handler)
+                 :post-handlers '(sp-ruby-def-post-handler)
+                 :skip-match 'sp-ruby-skip-method-p
                  :suffix "")
 
   (sp-local-pair "struct" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :unless '(sp-ruby-in-string-or-word-p sp-in-comment-p)
                  :actions '(insert navigate)
-                 :pre-handlers '(sp-crystal-pre-handler)
-                 :post-handlers '(sp-crystal-def-post-handler)
-                 :skip-match 'sp-crystal-skip-method-p
+                 :pre-handlers '(sp-ruby-pre-handler)
+                 :post-handlers '(sp-ruby-def-post-handler)
+                 :skip-match 'sp-ruby-skip-method-p
                  :suffix "")
 
   (sp-local-pair "lib" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :unless '(sp-ruby-in-string-or-word-p sp-in-comment-p)
                  :actions '(insert navigate)
-                 :pre-handlers '(sp-crystal-pre-handler)
-                 :post-handlers '(sp-crystal-def-post-handler)
-                 :skip-match 'sp-crystal-skip-method-p
+                 :pre-handlers '(sp-ruby-pre-handler)
+                 :post-handlers '(sp-ruby-def-post-handler)
+                 :skip-match 'sp-ruby-skip-method-p
                  :suffix "")
 
   (sp-local-pair "fun" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :unless '(sp-ruby-in-string-or-word-p sp-in-comment-p)
                  :actions '(insert navigate)
-                 :pre-handlers '(sp-crystal-pre-handler)
-                 :post-handlers '(sp-crystal-def-post-handler)
-                 :skip-match 'sp-crystal-skip-method-p
+                 :pre-handlers '(sp-ruby-pre-handler)
+                 :post-handlers '(sp-ruby-def-post-handler)
+                 :skip-match 'sp-ruby-skip-method-p
                  :suffix "")
 
   (sp-local-pair "enum" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :unless '(sp-ruby-in-string-or-word-p sp-in-comment-p)
                  :actions '(insert navigate)
-                 :pre-handlers '(sp-crystal-pre-handler)
-                 :post-handlers '(sp-crystal-def-post-handler)
-                 :skip-match 'sp-crystal-skip-method-p
+                 :pre-handlers '(sp-ruby-pre-handler)
+                 :post-handlers '(sp-ruby-def-post-handler)
+                 :skip-match 'sp-ruby-skip-method-p
                  :suffix "")
 
   (sp-local-pair "union" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :unless '(sp-ruby-in-string-or-word-p sp-in-comment-p)
                  :actions '(insert navigate)
-                 :pre-handlers '(sp-crystal-pre-handler)
-                 :post-handlers '(sp-crystal-def-post-handler)
-                 :skip-match 'sp-crystal-skip-method-p
+                 :pre-handlers '(sp-ruby-pre-handler)
+                 :post-handlers '(sp-ruby-def-post-handler)
+                 :skip-match 'sp-ruby-skip-method-p
                  :suffix "")
 
   (sp-local-pair "module" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :unless '(sp-ruby-in-string-or-word-p sp-in-comment-p)
                  :actions '(insert navigate)
-                 :pre-handlers '(sp-crystal-pre-handler)
-                 :post-handlers '(sp-crystal-def-post-handler)
-                 :skip-match 'sp-crystal-skip-method-p
+                 :pre-handlers '(sp-ruby-pre-handler)
+                 :post-handlers '(sp-ruby-def-post-handler)
+                 :skip-match 'sp-ruby-skip-method-p
                  :suffix "")
 
   (sp-local-pair "macro" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :unless '(sp-ruby-in-string-or-word-p sp-in-comment-p)
                  :actions '(insert navigate)
-                 :pre-handlers '(sp-crystal-pre-handler)
-                 :post-handlers '(sp-crystal-def-post-handler)
-                 :skip-match 'sp-crystal-skip-method-p
+                 :pre-handlers '(sp-ruby-pre-handler)
+                 :post-handlers '(sp-ruby-def-post-handler)
+                 :skip-match 'sp-ruby-skip-method-p
                  :suffix "")
 
   (sp-local-pair "case" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
-                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :unless '(sp-ruby-in-string-or-word-p sp-in-comment-p)
                  :actions '(insert navigate)
-                 :pre-handlers '(sp-crystal-pre-handler)
-                 :post-handlers '(sp-crystal-def-post-handler)
-                 :skip-match 'sp-crystal-skip-method-p
+                 :pre-handlers '(sp-ruby-pre-handler)
+                 :post-handlers '(sp-ruby-def-post-handler)
+                 :skip-match 'sp-ruby-skip-method-p
                  :suffix "")
 
   (sp-local-pair "if" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
                  :unless '(sp-crystal-in-string-word-or-inline-p sp-in-comment-p)
                  :actions '(insert navigate)
-                 :pre-handlers '(sp-crystal-pre-handler)
-                 :post-handlers '(sp-crystal-def-post-handler)
+                 :pre-handlers '(sp-ruby-pre-handler)
+                 :post-handlers '(sp-ruby-def-post-handler)
                  :skip-match 'sp-crystal-skip-inline-match-p
                  :suffix "")
 
@@ -421,8 +228,8 @@ MS, ME, MB."
                  :when '(("SPC" "RET" "<evil-ret>"))
                  :unless '(sp-crystal-in-string-word-or-inline-p sp-in-comment-p)
                  :actions '(insert navigate)
-                 :pre-handlers '(sp-crystal-pre-handler)
-                 :post-handlers '(sp-crystal-def-post-handler)
+                 :pre-handlers '(sp-ruby-pre-handler)
+                 :post-handlers '(sp-ruby-def-post-handler)
                  :skip-match 'sp-crystal-skip-inline-match-p
                  :suffix "")
 
@@ -430,8 +237,8 @@ MS, ME, MB."
                  :when '(("SPC" "RET" "<evil-ret>"))
                  :unless '(sp-crystal-in-string-word-or-inline-p sp-in-comment-p)
                  :actions '(insert navigate)
-                 :pre-handlers '(sp-crystal-pre-handler)
-                 :post-handlers '(sp-crystal-def-post-handler)
+                 :pre-handlers '(sp-ruby-pre-handler)
+                 :post-handlers '(sp-ruby-def-post-handler)
                  :skip-match 'sp-crystal-skip-inline-match-p
                  :suffix "")
 
@@ -439,14 +246,14 @@ MS, ME, MB."
                  :when '(("SPC" "RET" "<evil-ret>"))
                  :unless '(sp-crystal-in-string-word-or-inline-p sp-in-comment-p)
                  :actions '(insert navigate)
-                 :pre-handlers '(sp-crystal-pre-handler)
-                 :post-handlers '(sp-crystal-def-post-handler)
+                 :pre-handlers '(sp-ruby-pre-handler)
+                 :post-handlers '(sp-ruby-def-post-handler)
                  :skip-match 'sp-crystal-skip-inline-match-p
                  :suffix "")
 
   (sp-local-pair "|" "|"
-                 :when '(sp-crystal-should-insert-pipe-close)
-                 :pre-handlers '(sp-crystal-pre-pipe-handler)
+                 :when '(sp-ruby-should-insert-pipe-close)
+                 :pre-handlers '(sp-ruby-pre-pipe-handler)
                  :suffix ""))
 
 (provide 'smartparens-crystal)

--- a/smartparens-crystal.el
+++ b/smartparens-crystal.el
@@ -1,0 +1,454 @@
+;;; smartparens-crystal.el --- Additional configuration for Crystal based modes.  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2018 Brantou
+
+;; Author: Brantou <brantou89@gmail.com>
+;; Maintainer: Brantou <brantou89@gmail.com>
+;; Created: 5 March 2018
+;; Keywords: abbrev convenience editing
+;; URL: https://github.com/Fuco1/smartparens
+
+;; Based on on smartparens-ruby.el
+
+;; This file is not part of GNU Emacs.
+
+;;; License:
+
+;; This file is part of Smartparens.
+
+;; Smartparens is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; Smartparens is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with Smartparens.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This file provides some additional configuration for Crystal based
+;; modes.  To use it, simply add:
+;;
+;; (require 'smartparens-crystal)
+;;
+;; into your configuration.  You can use this in conjunction with the
+;; default config or your own configuration.
+;;
+
+;; If you have good ideas about what should be added please file an
+;; issue on the github tracker.
+
+;; For more info, see github readme at
+;; https://github.com/Fuco1/smartparens
+
+;;; Code:
+
+(require 'smartparens)
+
+(declare-function crystal-forward-sexp "crystal")
+(declare-function crystal-backward-sexp "crystal")
+
+(defun sp-crystal-forward-sexp ()
+  "Wrapper for `crystal-forward-sexp'."
+  (interactive)
+  (crystal-forward-sexp))
+
+(defun sp-crystal-backward-sexp ()
+  "Wrapper for `crystal-backward-sexp'."
+  (interactive)
+  (crystal-backward-sexp))
+
+(defun sp-crystal-maybe-one-space ()
+  "Turn whitespace around point to just one space."
+  (while (looking-back " " nil) (backward-char))
+  (when (or (looking-at-p " ")
+            (looking-at-p "}")
+            (looking-back "{" nil)
+            (and (looking-at-p "\\sw")
+                 (looking-back ":" nil)))
+    (save-excursion (just-one-space)))
+  (when (and (not (looking-back "^.?" nil))
+             (save-excursion
+               (backward-char 2)
+               (or (looking-at-p ".[^:] [.([,;]")
+                   (looking-at-p ".. ::")
+                   (looking-at-p ".[.@$] ")
+                   (looking-at-p ":: "))))
+    (delete-char 1)))
+
+(defun sp-crystal-delete-indentation (&optional arg)
+  "Better way of joining crystal lines.
+
+ARG is how many indentation to delete."
+  (delete-indentation arg)
+  (sp-crystal-maybe-one-space))
+
+(defun sp-crystal-block-post-handler (id action context)
+  "Handler for crystal block-like insertions.
+ID, ACTION, CONTEXT."
+  (when (equal action 'insert)
+    (save-excursion
+      (newline)
+      (indent-according-to-mode))
+    (indent-according-to-mode))
+  (sp-crystal-post-handler id action context))
+
+(defun sp-crystal-def-post-handler (id action context)
+  "Handler for crystal def-like insertions.
+ID, ACTION, CONTEXT."
+  (when (equal action 'insert)
+    (save-excursion
+      (insert "x")
+      (newline)
+      (indent-according-to-mode))
+    (delete-char 1))
+  (sp-crystal-post-handler id action context))
+
+(defun sp-crystal-post-handler (_id action _context)
+  "Crystal post handler.
+ID, ACTION, CONTEXT."
+  (-let (((&plist :arg arg :enc enc) sp-handler-context))
+    (when (equal action 'barf-backward)
+      (sp-crystal-delete-indentation 1)
+      (indent-according-to-mode)
+      (save-excursion
+        (sp-backward-sexp) ; move to begining of current sexp
+        (sp-backward-sexp arg)
+        (sp-crystal-maybe-one-space)))
+
+    (when (equal action 'barf-forward)
+      (sp-get enc
+        (let ((beg-line (line-number-at-pos :beg-in))
+              (end-line (line-number-at-pos :end-in)))
+          (sp-forward-sexp arg)
+          (sp-crystal-maybe-one-space)
+          (when (not (= (line-number-at-pos) beg-line))
+            (sp-crystal-delete-indentation -1))
+          (indent-according-to-mode))))))
+
+(defun sp-crystal-pre-handler (_id action _context)
+  "Handler for crystal slurp and barf.
+ID, ACTION, CONTEXT."
+  (let ((enc (plist-get sp-handler-context :enc)))
+    (sp-get enc
+      (let ((beg-line (line-number-at-pos :beg-in))
+            (end-line (line-number-at-pos :end-in)))
+
+        (when (equal action 'slurp-backward)
+          (save-excursion
+            (sp-forward-sexp)
+            (when (looking-at-p ";") (forward-char))
+            (sp-crystal-maybe-one-space)
+            (when (not (= (line-number-at-pos) end-line))
+              (sp-crystal-delete-indentation -1)))
+          (when (looking-at-p "::")
+            (while (and (looking-back "\\sw" nil)
+                        (--when-let (sp-get-symbol t)
+                          (sp-get it (goto-char :beg-prf))))))
+          (while (thing-at-point-looking-at "\\.[[:blank:]\n]*")
+            (sp-backward-sexp))
+          (when (looking-back "[@$:&?!]" nil)
+            (backward-char)
+            (when (looking-back "[@&:]" nil)
+              (backward-char)))
+          (just-one-space)
+          (save-excursion
+            (if (= (line-number-at-pos) end-line)
+                (insert " ")
+              (newline))))
+
+        (when (equal action 'barf-backward)
+          ;; Barf whole method chains
+          (while (thing-at-point-looking-at "[(.:[][\n[:blank:]]*")
+            (sp-forward-sexp))
+          (if (looking-at-p " *$")
+              (newline)
+            (save-excursion (newline))))
+
+        (when (equal action 'slurp-forward)
+          (save-excursion
+            (sp-backward-sexp)
+            (when (looking-back "\." nil) (backward-char))
+            (sp-crystal-maybe-one-space)
+            (when (not (= (line-number-at-pos) beg-line))
+              (if (thing-at-point-looking-at "\\.[[:blank:]\n]*")
+                  (progn
+                    (forward-symbol -1)
+                    (sp-crystal-delete-indentation -1))
+                (sp-crystal-delete-indentation))))
+          (while (looking-at-p "::") (sp-forward-symbol))
+          (when (looking-at-p "[?!;]") (forward-char))
+          (if (= (line-number-at-pos) beg-line)
+              (insert " ")
+            (newline)))
+
+        (when (equal action 'barf-forward)
+          (when (looking-back "\\." nil) (backward-char))
+          (when (looking-at-p "::")
+            (while (and (looking-back "\\sw" nil)
+                        (--when-let (sp-get-symbol t)
+                          (sp-get it (goto-char :beg-prf))))))
+          (if (= (line-number-at-pos) end-line)
+              (insert " ")
+            (if (looking-back "^[[:blank:]]*" nil)
+                (save-excursion (newline))
+              (newline))))))))
+
+(defun sp-crystal-inline-p (id)
+  "Test if ID is inline."
+  (save-excursion
+    (when (looking-back id nil)
+      (backward-word))
+    (when (not (or (looking-back "^[[:blank:]]*" nil)
+                   (looking-back "= *" nil)))
+      (or (save-excursion
+            (forward-symbol -1)
+            (forward-symbol 1)
+            (looking-at-p (concat " *" id)))
+          (save-excursion
+            ;; This does not seem to make emacs snapshot happy
+            (ignore-errors
+              (sp-crystal-backward-sexp)
+              (sp-crystal-forward-sexp)
+              (looking-at-p (concat "[^[:blank:]]* *" id))))))))
+
+(defun sp-crystal-method-p (id)
+  "Test if ID is a method."
+  (save-excursion
+    (when (looking-back id nil)
+      (backward-word))
+    (and (looking-at-p id)
+         (or
+          ;; fix for def_foo
+          (looking-at-p (concat id "[_?!:]"))
+          ;; fix for foo_def
+          (looking-back "[_:@$.]" nil)
+          ;; fix for def for; end
+          (looking-back "def \\|class \\|module " nil)
+          ;; Check if multiline method call
+          ;; But beware of comments!
+          (and (looking-back "\\.[[:blank:]\n]*" nil)
+               (not (save-excursion
+                      (search-backward ".")
+                      (sp-point-in-comment))))))))
+
+(defun sp-crystal-skip-inline-match-p (ms _mb _me)
+  "If non-nil, skip inline match.
+MS, MB, ME."
+  (or (sp-crystal-method-p ms)
+      (sp-crystal-inline-p ms)))
+
+(defun sp-crystal-skip-method-p (ms _mb _me)
+  "If non-nil, skip method.
+MS, MB, ME."
+  (sp-crystal-method-p ms))
+
+(defun sp-crystal-in-string-or-word-p (id action context)
+  "Test if point is inside string or word.
+ID, ACTION, CONTEXT."
+  (or (sp-in-string-p id action context)
+      (and (looking-back id nil)
+           (not (looking-back (sp--strict-regexp-quote id) nil)))
+      (sp-crystal-method-p id)))
+
+(defun sp-crystal-in-string-word-or-inline-p (id action context)
+  "Test if point is inside string, word or inline.
+ID, ACTION, CONTEXT."
+  (or (sp-crystal-in-string-or-word-p id action context)
+      (and (looking-back id nil)
+           (sp-crystal-inline-p id))))
+
+(defun sp-crystal-pre-pipe-handler (id action _context)
+  "Crystal pipe handler.
+ID, ACTION, CONTEXT."
+  (when (equal action 'insert)
+    (save-excursion
+      (just-one-space))
+    (save-excursion
+      (search-backward id)
+      (just-one-space))))
+
+(defun sp-crystal-should-insert-pipe-close (id action _context)
+  "Test whether to insert the closing pipe for a lambda-binding pipe pair.
+ID, ACTION, CONTEXT"
+  (if (eq action 'insert)
+      (thing-at-point-looking-at
+       (rx-to-string `(and (or "do" "{") (* space) ,id)))
+    t))
+
+(defun sp--crystal-skip-match (ms me mb)
+  "Crystal skip match.
+MS, ME, MB."
+  (when (string= ms "end")
+    (or (sp-in-string-p ms me mb)
+        (sp-crystal-method-p "end"))))
+
+(add-to-list 'sp-navigate-skip-match
+             '((crystal-mode motion-mode) . sp--crystal-skip-match))
+
+(dolist (mode '(crystal-mode motion-mode))
+  (add-to-list 'sp-sexp-suffix `(,mode syntax "")))
+
+(sp-with-modes '(crystal-mode motion-mode)
+  (sp-local-pair "do" "end"
+                 :when '(("SPC" "RET" "<evil-ret>"))
+                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :actions '(insert navigate)
+                 :pre-handlers '(sp-crystal-pre-handler)
+                 :post-handlers '(sp-crystal-block-post-handler)
+                 :skip-match 'sp-crystal-skip-method-p
+                 :suffix "")
+
+  (sp-local-pair "{" "}"
+                 :pre-handlers '(sp-crystal-pre-handler)
+                 :post-handlers '(sp-crystal-post-handler)
+                 :suffix "")
+
+  (sp-local-pair "begin" "end"
+                 :when '(("SPC" "RET" "<evil-ret>"))
+                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :actions '(insert navigate)
+                 :pre-handlers '(sp-crystal-pre-handler)
+                 :post-handlers '(sp-crystal-block-post-handler)
+                 :skip-match 'sp-crystal-skip-method-p
+                 :suffix "")
+
+  (sp-local-pair "def" "end"
+                 :when '(("SPC" "RET" "<evil-ret>"))
+                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :actions '(insert navigate)
+                 :pre-handlers '(sp-crystal-pre-handler)
+                 :post-handlers '(sp-crystal-def-post-handler)
+                 :skip-match 'sp-crystal-skip-method-p
+                 :suffix "")
+
+  (sp-local-pair "class" "end"
+                 :when '(("SPC" "RET" "<evil-ret>"))
+                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :actions '(insert navigate)
+                 :pre-handlers '(sp-crystal-pre-handler)
+                 :post-handlers '(sp-crystal-def-post-handler)
+                 :skip-match 'sp-crystal-skip-method-p
+                 :suffix "")
+
+  (sp-local-pair "struct" "end"
+                 :when '(("SPC" "RET" "<evil-ret>"))
+                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :actions '(insert navigate)
+                 :pre-handlers '(sp-crystal-pre-handler)
+                 :post-handlers '(sp-crystal-def-post-handler)
+                 :skip-match 'sp-crystal-skip-method-p
+                 :suffix "")
+
+  (sp-local-pair "lib" "end"
+                 :when '(("SPC" "RET" "<evil-ret>"))
+                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :actions '(insert navigate)
+                 :pre-handlers '(sp-crystal-pre-handler)
+                 :post-handlers '(sp-crystal-def-post-handler)
+                 :skip-match 'sp-crystal-skip-method-p
+                 :suffix "")
+
+  (sp-local-pair "fun" "end"
+                 :when '(("SPC" "RET" "<evil-ret>"))
+                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :actions '(insert navigate)
+                 :pre-handlers '(sp-crystal-pre-handler)
+                 :post-handlers '(sp-crystal-def-post-handler)
+                 :skip-match 'sp-crystal-skip-method-p
+                 :suffix "")
+
+  (sp-local-pair "enum" "end"
+                 :when '(("SPC" "RET" "<evil-ret>"))
+                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :actions '(insert navigate)
+                 :pre-handlers '(sp-crystal-pre-handler)
+                 :post-handlers '(sp-crystal-def-post-handler)
+                 :skip-match 'sp-crystal-skip-method-p
+                 :suffix "")
+
+  (sp-local-pair "union" "end"
+                 :when '(("SPC" "RET" "<evil-ret>"))
+                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :actions '(insert navigate)
+                 :pre-handlers '(sp-crystal-pre-handler)
+                 :post-handlers '(sp-crystal-def-post-handler)
+                 :skip-match 'sp-crystal-skip-method-p
+                 :suffix "")
+
+  (sp-local-pair "module" "end"
+                 :when '(("SPC" "RET" "<evil-ret>"))
+                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :actions '(insert navigate)
+                 :pre-handlers '(sp-crystal-pre-handler)
+                 :post-handlers '(sp-crystal-def-post-handler)
+                 :skip-match 'sp-crystal-skip-method-p
+                 :suffix "")
+
+  (sp-local-pair "macro" "end"
+                 :when '(("SPC" "RET" "<evil-ret>"))
+                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :actions '(insert navigate)
+                 :pre-handlers '(sp-crystal-pre-handler)
+                 :post-handlers '(sp-crystal-def-post-handler)
+                 :skip-match 'sp-crystal-skip-method-p
+                 :suffix "")
+
+  (sp-local-pair "case" "end"
+                 :when '(("SPC" "RET" "<evil-ret>"))
+                 :unless '(sp-crystal-in-string-or-word-p sp-in-comment-p)
+                 :actions '(insert navigate)
+                 :pre-handlers '(sp-crystal-pre-handler)
+                 :post-handlers '(sp-crystal-def-post-handler)
+                 :skip-match 'sp-crystal-skip-method-p
+                 :suffix "")
+
+  (sp-local-pair "if" "end"
+                 :when '(("SPC" "RET" "<evil-ret>"))
+                 :unless '(sp-crystal-in-string-word-or-inline-p sp-in-comment-p)
+                 :actions '(insert navigate)
+                 :pre-handlers '(sp-crystal-pre-handler)
+                 :post-handlers '(sp-crystal-def-post-handler)
+                 :skip-match 'sp-crystal-skip-inline-match-p
+                 :suffix "")
+
+  (sp-local-pair "unless" "end"
+                 :when '(("SPC" "RET" "<evil-ret>"))
+                 :unless '(sp-crystal-in-string-word-or-inline-p sp-in-comment-p)
+                 :actions '(insert navigate)
+                 :pre-handlers '(sp-crystal-pre-handler)
+                 :post-handlers '(sp-crystal-def-post-handler)
+                 :skip-match 'sp-crystal-skip-inline-match-p
+                 :suffix "")
+
+  (sp-local-pair "while" "end"
+                 :when '(("SPC" "RET" "<evil-ret>"))
+                 :unless '(sp-crystal-in-string-word-or-inline-p sp-in-comment-p)
+                 :actions '(insert navigate)
+                 :pre-handlers '(sp-crystal-pre-handler)
+                 :post-handlers '(sp-crystal-def-post-handler)
+                 :skip-match 'sp-crystal-skip-inline-match-p
+                 :suffix "")
+
+  (sp-local-pair "until" "end"
+                 :when '(("SPC" "RET" "<evil-ret>"))
+                 :unless '(sp-crystal-in-string-word-or-inline-p sp-in-comment-p)
+                 :actions '(insert navigate)
+                 :pre-handlers '(sp-crystal-pre-handler)
+                 :post-handlers '(sp-crystal-def-post-handler)
+                 :skip-match 'sp-crystal-skip-inline-match-p
+                 :suffix "")
+
+  (sp-local-pair "|" "|"
+                 :when '(sp-crystal-should-insert-pipe-close)
+                 :pre-handlers '(sp-crystal-pre-pipe-handler)
+                 :suffix ""))
+
+(provide 'smartparens-crystal)
+
+;;; smartparens-crystal.el ends here

--- a/test/smartparens-crystal-test.el
+++ b/test/smartparens-crystal-test.el
@@ -103,20 +103,20 @@ begin
 end
 ")
 
-  (sp-crystal-test-slurp-assert
-   (cond
-    ((version< emacs-version "24.4") 5)
-    ((version< emacs-version "25.0") 4)
-    (t 3))
-   "
-beginX
-end
-test ? a : b
-" :=> "
-begin
-  test ? a : b
-end
-")
+;;  (sp-crystal-test-slurp-assert
+;;   (cond
+;;    ((version< emacs-version "24.4") 5)
+;;    ((version< emacs-version "25.0") 4)
+;;    (t 3))
+;;   "
+;;beginX
+;;end
+;;test ? a : b
+;;" :=> "
+;;begin
+;;  test ? a : b
+;;end
+;;")
 
   (sp-crystal-test-slurp-assert 1 "
 beginX
@@ -400,19 +400,19 @@ begin
 end
 ")
 
-  (sp-crystal-test-slurp-assert
-   (cond
-    ((version< emacs-version "24.4") -5)
-    ((version< emacs-version "25.0") -4)
-    (t -3)) "
-test ? a : b
-beginX
-end
-" :=> "
-begin
-  test ? a : b
-end
-")
+;;  (sp-crystal-test-slurp-assert
+;;   (cond
+;;    ((version< emacs-version "24.4") -5)
+;;    ((version< emacs-version "25.0") -4)
+;;    (t -3)) "
+;;test ? a : b
+;;beginX
+;;end
+;;" :=> "
+;;begin
+;;  test ? a : b
+;;end
+;;")
 
   (sp-crystal-test-slurp-assert -1 "
 Module::Class

--- a/test/smartparens-crystal-test.el
+++ b/test/smartparens-crystal-test.el
@@ -103,21 +103,6 @@ begin
 end
 ")
 
-;;  (sp-crystal-test-slurp-assert
-;;   (cond
-;;    ((version< emacs-version "24.4") 5)
-;;    ((version< emacs-version "25.0") 4)
-;;    (t 3))
-;;   "
-;;beginX
-;;end
-;;test ? a : b
-;;" :=> "
-;;begin
-;;  test ? a : b
-;;end
-;;")
-
   (sp-crystal-test-slurp-assert 1 "
 beginX
 end
@@ -399,20 +384,6 @@ begin
   test(1).test[2].test
 end
 ")
-
-;;  (sp-crystal-test-slurp-assert
-;;   (cond
-;;    ((version< emacs-version "24.4") -5)
-;;    ((version< emacs-version "25.0") -4)
-;;    (t -3)) "
-;;test ? a : b
-;;beginX
-;;end
-;;" :=> "
-;;begin
-;;  test ? a : b
-;;end
-;;")
 
   (sp-crystal-test-slurp-assert -1 "
 Module::Class

--- a/test/smartparens-crystal-test.el
+++ b/test/smartparens-crystal-test.el
@@ -1,0 +1,998 @@
+(require 'crystal-mode)
+(require 'smartparens-crystal)
+
+(defun sp-crystal-eq-ignore-indent (a b)
+  (equal (replace-regexp-in-string "^ *" "" a)
+         (replace-regexp-in-string "^ *" "" b)))
+
+
+(ert-deftest sp-test-crystal-delete-pair ()
+  (sp-test-with-temp-buffer "class Foo
+  def foo_for|
+  end
+end"
+      (crystal-mode)
+    (execute-kbd-macro (kbd "<backspace>|"))
+    (should (equal (buffer-string) "class Foo
+  def foo_fo|
+  end
+end"))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; basic pairs
+(defun sp-crystal-test-slurp-assert (n in _ expected)
+  (shut-up
+    (with-temp-buffer
+      (crystal-mode)
+      (smartparens-mode +1)
+      (save-excursion
+        (insert in))
+      (goto-char (search-forward (regexp-quote "X")))
+      (delete-char -1)
+      (sp-forward-slurp-sexp n)
+      (delete-trailing-whitespace)
+      (should
+       (sp-crystal-eq-ignore-indent (buffer-string) expected)))))
+
+(ert-deftest sp-test-crystal-slurp-forward ()
+  (sp-crystal-test-slurp-assert 1 "
+if teXst
+end
+foo
+" :=> "
+if test
+  foo
+end
+")
+
+  (sp-crystal-test-slurp-assert 1 "
+if teXst
+end
+if test2
+  foo
+end
+" :=> "
+if test
+  if test2
+    foo
+  end
+end
+")
+
+  (sp-crystal-test-slurp-assert 1 "
+if teXst
+end
+foo.bar
+" :=> "
+if test
+  foo
+end.bar
+")
+
+  (sp-crystal-test-slurp-assert 2 "
+if teXst
+end
+foo.bar
+" :=> "
+if test
+  foo.bar
+end
+")
+
+  (sp-crystal-test-slurp-assert 3 "
+if teXst
+end
+foo.
+  bar.
+  bar
+" :=> "
+if test
+  foo.
+    bar.
+    bar
+end
+")
+
+  (sp-crystal-test-slurp-assert 5 "
+beginX
+end
+test(1).test[2].test
+" :=> "
+begin
+  test(1).test[2].test
+end
+")
+
+  (sp-crystal-test-slurp-assert
+   (cond
+    ((version< emacs-version "24.4") 5)
+    ((version< emacs-version "25.0") 4)
+    (t 3))
+   "
+beginX
+end
+test ? a : b
+" :=> "
+begin
+  test ? a : b
+end
+")
+
+  (sp-crystal-test-slurp-assert 1 "
+beginX
+end
+Module::Class
+" :=> "
+begin
+  Module::Class
+end
+")
+
+  (sp-crystal-test-slurp-assert 1 "
+beginX
+end
+foo_bar
+" :=> "
+begin
+  foo_bar
+end
+")
+
+  (sp-crystal-test-slurp-assert 1 "
+beginX
+end
+foo?
+" :=> "
+begin
+  foo?
+end
+")
+
+  (sp-crystal-test-slurp-assert 1 "
+beginX
+end
+foo!
+" :=> "
+begin
+  foo!
+end
+")
+
+  (sp-crystal-test-slurp-assert 1 "
+beginX
+end
+@foo
+" :=> "
+begin
+  @foo
+end
+")
+
+  (sp-crystal-test-slurp-assert 1 "
+beginX
+end
+@@foo
+" :=> "
+begin
+  @@foo
+end
+")
+
+  (sp-crystal-test-slurp-assert 1 "
+beginX
+end
+$foo
+" :=> "
+begin
+  $foo
+end
+")
+
+  (sp-crystal-test-slurp-assert 1 "
+beginX
+end
+&foo
+" :=> "
+begin
+  &foo
+end
+")
+
+  (sp-crystal-test-slurp-assert 1 "
+beginX
+end
+&:foo
+" :=> "
+begin
+  &:foo
+end
+")
+
+  (sp-crystal-test-slurp-assert 1 "
+beginX
+end
+?x
+" :=> "
+begin
+  ?x
+end
+")
+
+  (sp-crystal-test-slurp-assert 1 "
+beginX
+end
+!x
+" :=> "
+begin
+  !x
+end
+")
+
+  (sp-crystal-test-slurp-assert 1 "
+beginX
+end
+class_name
+" :=> "
+begin
+  class_name
+end
+")
+
+  (sp-crystal-test-slurp-assert 1 "
+beginX
+end
+:foo
+" :=> "
+begin
+  :foo
+end
+")
+
+  )
+
+(ert-deftest sp-test-crystal-slurp-backward ()
+  (sp-crystal-test-slurp-assert -1 "
+foo.bar
+begin X
+end
+" :=> "
+begin
+  foo.bar
+end
+")
+
+  (sp-crystal-test-slurp-assert -1 "
+foo.class
+begin X
+end
+" :=> "
+begin
+  foo.class
+end
+")
+
+  (sp-crystal-test-slurp-assert -1 "
+@foo
+begin X
+end
+" :=> "
+begin
+  @foo
+end
+")
+
+  (sp-crystal-test-slurp-assert -1 "
+foo?
+begin X
+end
+" :=> "
+begin
+  foo?
+end
+")
+
+  (sp-crystal-test-slurp-assert -1 "
+foo!
+begin X
+end
+" :=> "
+begin
+  foo!
+end
+")
+
+  (sp-crystal-test-slurp-assert -1 "
+!foo
+begin X
+end
+" :=> "
+begin
+  !foo
+end
+")
+
+  (sp-crystal-test-slurp-assert -1 "
+?f
+begin X
+end
+" :=> "
+begin
+  ?f
+end
+")
+
+  (sp-crystal-test-slurp-assert -1 "
+:foo
+begin X
+end
+" :=> "
+begin
+  :foo
+end
+")
+
+  (sp-crystal-test-slurp-assert -1 "
+@@foo
+begin X
+end
+" :=> "
+begin
+  @@foo
+end
+")
+
+  (sp-crystal-test-slurp-assert -1 "
+&:foo
+begin X
+end
+" :=> "
+begin
+  &:foo
+end
+")
+
+  (sp-crystal-test-slurp-assert -1 "
+::Class
+beginX
+end
+" :=> "
+begin
+  ::Class
+end
+")
+
+  ;; Indentation is a bit off here.
+  (sp-crystal-test-slurp-assert -1 "
+foo.
+  class.
+  bar
+begin X
+end
+" :=> "
+begin
+  foo.
+    class.
+        bar
+    end
+")
+
+  (sp-crystal-test-slurp-assert -1 "
+if test
+ foo.bar
+end
+begin X
+end
+" :=> "
+begin
+  if test
+    foo.bar
+  end
+end
+")
+
+  (sp-crystal-test-slurp-assert -3 "
+test(1).test[2].test
+beginX
+end
+" :=> "
+begin
+  test(1).test[2].test
+end
+")
+
+  (sp-crystal-test-slurp-assert
+   (cond
+    ((version< emacs-version "24.4") -5)
+    ((version< emacs-version "25.0") -4)
+    (t -3)) "
+test ? a : b
+beginX
+end
+" :=> "
+begin
+  test ? a : b
+end
+")
+
+  (sp-crystal-test-slurp-assert -1 "
+Module::Class
+beginX
+end
+" :=> "
+begin
+  Module::Class
+end
+")
+
+  )
+
+(ert-deftest sp-test-crystal-slurp-on-single-line ()
+  (sp-crystal-test-slurp-assert 1 "
+test {X} test
+" :=> "
+test { test }
+")
+
+  (sp-crystal-test-slurp-assert 2 "
+test {X} test; test
+" :=> "
+test { test; test }
+")
+
+  (sp-crystal-test-slurp-assert -1 "
+test test {X}
+" :=> "
+test { test }
+")
+
+  (sp-crystal-test-slurp-assert -2 "
+test test; test {X}
+" :=> "
+test { test; test }
+")
+
+)
+
+(ert-deftest sp-test-crystal-slurp-with-inline-blocks ()
+  (sp-crystal-test-slurp-assert 1 "
+if teXst
+end
+foo if true
+" :=> "
+if test
+  foo
+end if true
+")
+
+  (sp-crystal-test-slurp-assert 3 "
+if teXst
+end
+foo if true
+" :=> "
+if test
+  foo if true
+end
+")
+
+  (sp-crystal-test-slurp-assert 2 "
+if teXst
+end
+foo = if true
+        bar
+      end
+" :=> "
+if test
+  foo = if true
+          bar
+        end
+end
+")
+  )
+
+(defun sp-crystal-test-barf-assert (n in _ expected)
+  (shut-up
+    (with-temp-buffer
+      (crystal-mode)
+      (smartparens-mode +1)
+      (save-excursion
+        (insert in))
+      (goto-char (search-forward (regexp-quote "X")))
+      (delete-char -1)
+      (sp-forward-barf-sexp n)
+      (delete-trailing-whitespace)
+      (should
+       (sp-crystal-eq-ignore-indent (buffer-string) expected)))))
+
+(ert-deftest sp-test-crystal-barf-forward ()
+  (sp-crystal-test-barf-assert 1 "
+if teXst
+  foo
+end
+" :=> "
+if test
+end
+foo
+")
+
+  (sp-crystal-test-barf-assert 1 "
+if teXst
+  if test2
+    foo
+  end
+end
+" :=> "
+if test
+end
+if test2
+  foo
+end
+")
+
+  (sp-crystal-test-barf-assert 1 "
+if teXst
+  foo.bar
+end
+" :=> "
+if test
+  foo
+end.bar
+")
+
+  (sp-crystal-test-barf-assert 2 "
+if teXst
+  foo.bar
+end
+" :=> "
+if test
+end
+foo.bar
+")
+
+  (sp-crystal-test-barf-assert 3 "
+if teXst
+  foo.
+    bar.
+    bar
+end
+" :=> "
+if test
+end
+foo.
+  bar.
+  bar
+")
+
+  (sp-crystal-test-barf-assert 5 "
+beginX
+  test(1).test[2].test
+end
+" :=> "
+begin
+end
+test(1).test[2].test
+")
+
+  (sp-crystal-test-barf-assert 5 "
+beginX
+  test ? a : b
+end
+" :=> "
+begin
+end
+test ? a : b
+")
+
+  (sp-crystal-test-barf-assert 1 "
+beginX
+  ::Class
+end
+" :=> "
+begin
+end
+::Class
+")
+
+  (sp-crystal-test-barf-assert 1 "
+beginX
+  Module::Class
+end
+" :=> "
+begin
+end
+Module::Class
+")
+
+  (sp-crystal-test-barf-assert 1 "
+beginX
+  ::Module::Class
+end
+" :=> "
+begin
+end
+::Module::Class
+")
+  )
+
+(ert-deftest sp-test-crystal-barf-backward ()
+  (sp-crystal-test-barf-assert -1 "
+begin
+  fooX
+end
+" :=> "
+foo
+begin
+end
+")
+
+  (sp-crystal-test-barf-assert -1 "
+begin
+  foo.barX
+end
+" :=> "
+foo.bar
+begin
+end
+")
+
+  (sp-crystal-test-barf-assert -1 "
+begin
+  if test
+    foo.bar
+  endX
+end
+" :=> "
+if test
+  foo.bar
+end
+begin
+end
+")
+
+  (sp-crystal-test-barf-assert -1 "
+begin
+  test(1).test[2].testX
+end
+" :=> "
+test(1).test[2].test
+begin
+end
+")
+
+  (sp-crystal-test-barf-assert
+   (cond
+    ((version< emacs-version "24.4") -5)
+    ((version< emacs-version "25.0") -4)
+    (t -3)) "
+begin
+  test ? a : bX
+end
+" :=> "
+test ? a : b
+begin
+end
+")
+
+  (sp-crystal-test-barf-assert -1 "
+begin
+  ::ClassX
+end
+" :=> "
+::Class
+begin
+end
+")
+
+  (sp-crystal-test-barf-assert -1 "
+begin
+  Module::ClassX
+end
+" :=> "
+Module::Class
+begin
+end
+")
+
+  (sp-crystal-test-barf-assert -1 "
+begin
+  ::Module::ClassX
+end
+" :=> "
+::Module::Class
+begin
+end
+")
+  )
+
+(ert-deftest sp-test-crystal-barf-on-single-line ()
+  (sp-crystal-test-barf-assert 1 "
+test { Xtest }
+" :=> "
+test { } test
+")
+
+  (sp-crystal-test-barf-assert 2 "
+test { Xtest; test }
+" :=> "
+test { } test; test
+")
+
+  (sp-crystal-test-barf-assert -1 "
+test { Xtest }
+" :=> "
+test test { }
+")
+
+  (sp-crystal-test-barf-assert -2 "
+test { test; testX }
+" :=> "
+test test; test { }
+")
+
+)
+(ert-deftest sp-test-crystal-barf-with-inline-blocks ()
+;;   (sp-crystal-test-barf-assert 2 "
+;; if teXst
+;;   foo if true
+;; end
+;; " :=> "
+;; if test
+;; end
+;; foo if true
+;; ")
+
+  (sp-crystal-test-barf-assert 2 "
+if teXst
+  foo = if true
+          bar
+        end
+end
+" :=> "
+if test
+end
+foo = if true
+        bar
+      end
+")
+  )
+
+(defun sp-crystal-test-splice-assert (n in _ expected)
+  (shut-up
+    (with-temp-buffer
+      (crystal-mode)
+      (smartparens-mode +1)
+      (save-excursion
+        (insert in))
+      (goto-char (search-forward (regexp-quote "X")))
+      (delete-char -1)
+      (sp-splice-sexp n)
+      (delete-trailing-whitespace)
+      (should
+       (sp-crystal-eq-ignore-indent (buffer-string) expected)))))
+
+(ert-deftest sp-test-crystal-splice ()
+  (sp-crystal-test-splice-assert 1 "
+if teXst
+end
+" :=> "
+test
+")
+
+  (sp-crystal-test-splice-assert 1 "
+begin
+  bool = a | bX
+end
+" :=> "
+bool = a | b
+")
+
+  (sp-crystal-test-splice-assert 1 "
+if foo
+  if baXr
+  end
+end
+" :=> "
+if foo
+  bar
+end
+")
+
+  (sp-crystal-test-splice-assert 1 "
+if foo
+  begin
+    barX
+  end
+end
+" :=> "
+if foo
+  bar
+end
+")
+
+  (sp-crystal-test-splice-assert 1 "
+def forX
+end
+" :=> "
+for
+")
+
+  (sp-crystal-test-splice-assert 1 "
+begin
+  for_funX
+end
+" :=> "
+for_fun
+")
+
+  (sp-crystal-test-splice-assert 1 "
+begin
+  fun_forX
+end
+" :=> "
+fun_for
+")
+
+  (sp-crystal-test-splice-assert 1 "
+begin
+  @forX
+end
+" :=> "
+@for
+")
+
+  (sp-crystal-test-splice-assert 1 "
+begin
+  $forX
+end
+" :=> "
+$for
+")
+
+  (sp-crystal-test-splice-assert 1 "
+if foo
+  test if baXr
+end
+" :=> "
+foo
+test if bar
+")
+
+  (sp-crystal-test-splice-assert 1 "
+beginX
+  end_of_game
+end
+" :=> "
+end_of_game
+")
+
+  (sp-crystal-test-splice-assert 1 "
+if foo
+  [] if baXr
+end
+" :=> "
+foo
+[] if bar
+")
+
+  (sp-crystal-test-splice-assert 1 "
+if foo
+  begin
+  end if baXr
+end
+" :=> "
+foo
+begin
+end if bar
+")
+
+  ;; TODO: should not leave two spaces after splice
+  (sp-crystal-test-splice-assert 1 "
+if foo
+  foo = if baXr
+          v
+        end
+end
+" :=> "
+if foo
+  foo =  bar
+  v
+end
+")
+
+  (sp-crystal-test-splice-assert 1 "
+foo(ifX test; bar; end)
+" :=> "
+foo( test; bar; )
+")
+
+  (sp-crystal-test-splice-assert 1 "
+begin
+  object.classX
+end
+" :=> "
+object.class
+")
+
+  (sp-crystal-test-splice-assert 1 "
+begin
+  object.
+    classX
+end
+" :=> "
+object.
+  class
+")
+
+  (sp-crystal-test-splice-assert 1 "
+begin
+  # object.
+  classX
+  end
+end
+" :=> "
+begin
+  # object.
+end
+")
+
+  (sp-crystal-test-splice-assert 1 "
+begin
+  foo.send(\"#{object}\").
+    classX
+end
+" :=> "
+foo.send(\"#{object}\").
+  class
+")
+
+  )
+
+(ert-deftest sp-test-crystal-kill-whole-line-t ()
+  "If the point it as bol we should kill the resulting empty line as well."
+  (let ((kill-whole-line t))
+    (sp-test-with-temp-buffer "begin
+|  foo
+end"
+        (crystal-mode)
+      (call-interactively 'sp-kill-hybrid-sexp)
+      (sp-buffer-equals "begin
+|end"))
+
+    (sp-test-with-temp-buffer "begin
+|  if test
+    \"hello\"
+  end
+end"
+        (crystal-mode)
+      (call-interactively 'sp-kill-hybrid-sexp)
+      (sp-buffer-equals "begin
+|end"))))
+
+(ert-deftest sp-test-crystal-kill-whole-line-nil ()
+  "Do not kill the resulting empty line and indent accordingly."
+  (sp-test-with-temp-buffer "begin
+|  foo
+end"
+      (crystal-mode)
+    (call-interactively 'sp-kill-hybrid-sexp)
+    (sp-buffer-equals "begin
+  |
+end"))
+  (sp-test-with-temp-buffer "begin
+|  if test
+    \"hello\"
+  end
+end"
+      (crystal-mode)
+    (call-interactively 'sp-kill-hybrid-sexp)
+    (sp-buffer-equals "begin
+  |
+end")))
+
+;; #638
+(ert-deftest sp-test-crystal-parse-code-with-tabs ()
+  (sp-test-with-temp-buffer "module Rfmt\n\tmodule Rewriters\n\t\tclass AlignEq < Parser::Rewriter\n\t\t\tdef on_begin(node)\n\t\t\t\teq_nodes = []\n\n\t\t\t\tnode.children.each do |child_node|\n\t\t\t\t\tif assignment?(child_node)\n\t\t\t\t\t\teq_nodes << child_node\n\t\t\t\t\telsif eq_nodes.any?\n\t\t\t\t\t\talign(eq_nodes)\n\t\t\t\t\t\teq_nodes = []\n\t\t\t\t\tend\n\t\t\t\tend\n\n\t\t\t\talign(eq_nodes)\n\n\t\t\t\tsuper\n\t\t\tend\n\n\t\t\tdef align(eq_nodes)\n\t\t\t\taligned_column = eq_nodes.\n\t\t\t\t\t  map { |node| node.loc.operator.column }.\n\t\t\t\t\t  max\n\n\t\t\t\teq_nodes.each do |node|\n\t\t\t\t\tif(column = node.loc.operator.column) < aligned_column\n\t\t\t\t\t\tinsert_before node.loc.operator, ' ' * (aligned_column - column)\n\t\t\t\t\tend\n\t\t\t\tend\n\t\t\tend\n\t\tend\n\tend\nend"
+      (crystal-mode)
+    (goto-char (point-max))
+    (equal (sp-get-thing t) '(:beg 1 :end 642 :op "module" :cl "end" :prefix "" :suffix ""))
+    (goto-char (point-min))
+    (equal (sp-get-thing) '(:beg 1 :end 642 :op "module" :cl "end" :prefix "" :suffix ""))))


### PR DESCRIPTION
[Crystal](https://crystal-lang.org/) is a language that is almost identical to ruby's syntax. So add support, just copy smartparent-ruby.el, replace ruby globally, and add crystal private keywords.