### PR TITLE
ignore arrow function syntax "=>" in javascript-modes

### DIFF
--- a/smartparens-javascript.el
+++ b/smartparens-javascript.el
@@ -46,10 +46,28 @@
 
 (require 'smartparens)
 
+(defvar sp--javascript-modes '(
+                               js-mode
+                               javascript-mode
+                               js2-mode
+                               typescript-mode
+                               )
+  "List of JavaScript modes.")
+
 ;; (|sys).path.append---the dot should not travel with the closing
 ;; paren
-(--each '(js-mode javascript-mode js2-mode typescript-mode)
+(--each sp--javascript-modes
   (add-to-list 'sp-sexp-suffix (list it 'regexp "")))
+
+(defun sp-javascript-skip-match-angle-bracket (_ms _mb me)
+  "Non-nil if we should ignore the bracket as valid delimiter."
+  (save-excursion
+    (goto-char me)
+    (sp--looking-back-p (rx "=>") nil)))
+
+(sp-with-modes sp--javascript-modes
+  (sp-local-pair "<" ">"
+               :skip-match 'sp-javascript-skip-match-angle-bracket))
 
 (provide 'smartparens-javascript)
 ;;; smartparens-javasript.el ends here


### PR DESCRIPTION
close #872 
Do I need to add a test for this?
Also I notice the modes list in `smartparens-javascript.el` is different from `smartparens-config.el`, will this be a problem?