### PR TITLE
Break from sp--looking-back early if input is pending

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -4205,7 +4205,9 @@ sequence, not necessarily the longest possible."
           (save-excursion
             (goto-char from)
             (save-match-data
-              (while (and (not has-match) (< (point) to))
+              (while (and (not (input-pending-p))
+                          (not has-match)
+                          (< (point) to))
                 ;; don't use looking-at because we can't limit that search
                 (if (and (save-excursion (re-search-forward regexp to t))
                          (= (match-end 0) to))


### PR DESCRIPTION
As mentioned on #881, this is probably not a good idea. I don't actually know
the effects of allowing sp--looking-back to end early in all cases. For
`sp-show--pair-function` it seems to be fine, but it would probably break other
smartparens operations.

Perhaps a var could be `let` in `sp-show--pair-function` that would allow
`sp--looking-back` to abort in this way?