### PR TITLE
Add .dir-locals-2.el to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ elpa
 *.elc
 *~*
 docs/_build
+.dir-locals-2.el


### PR DESCRIPTION
This allows people to customize directory-local variables for Smartparens without leaving unstaged changes or untracked files in the Git repository. (Support for `.dir-locals-2.el` is new in Emacs 26.)