### PR TITLE
Added link to default-configuration

### DIFF
--- a/docs/example-configuration.rst
+++ b/docs/example-configuration.rst
@@ -3,4 +3,4 @@
 Example configuration
 =======
 
-The latest working configuration of the author can be found at `GitHub <https://github.com/Fuco1/.emacs.d/blob/master/files/smartparens.el>`_. Before looking at it, have a look at the :ref:`default-configuration` for things already set up for you!
+The latest working configuration of the author can be found at `GitHub <https://github.com/Fuco1/.emacs.d/blob/master/files/smartparens.el>`_. Before looking at it, have a look at the `default-configuration <https://github.com/Fuco1/smartparens/blob/master/smartparens-config.el>`_ for things already set up for you!


### PR DESCRIPTION
For a user coming to readthedocs, it is not immediately clear where the default configuration can be found (although she might guess that this place is also on Github ;-).