### PR TITLE
Ability to highlight a pair's content

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -9223,6 +9223,11 @@ the opening delimiter or before the closing delimiter."
   "The face used to highlight pair overlays."
   :group 'show-smartparens)
 
+(defface sp-show-pair-match-content-face
+  '()
+  "`show-smartparens-mode' face used for a matching pair's content."
+  :group 'show-smartparens)
+
 (defvar sp-show-pair-idle-timer nil)
 
 (defvar sp-show-pair-overlays nil)
@@ -9355,11 +9360,14 @@ matching paren in the echo area if not visible on screen."
   (when sp-show-pair-overlays
     (sp-show--pair-delete-overlays))
   (let* ((oleft (make-overlay start (+ start olen) nil t nil))
+         (omiddle (make-overlay (+ start olen) (- end clen) nil t nil))
          (oright (make-overlay (- end clen) end nil t nil)))
-    (setq sp-show-pair-overlays (cons oleft oright))
+    (setq sp-show-pair-overlays (list oleft omiddle oright))
     (overlay-put oleft 'face 'sp-show-pair-match-face)
+    (overlay-put omiddle 'face 'sp-show-pair-match-content-face)
     (overlay-put oright 'face 'sp-show-pair-match-face)
     (overlay-put oleft 'priority 1000)
+    (overlay-put omiddle 'priority 1000)
     (overlay-put oright 'priority 1000)
     (overlay-put oleft 'type 'show-pair)))
 
@@ -9416,7 +9424,7 @@ has been created."
   (when sp-show-pair-overlays
     (sp-show--pair-delete-overlays))
   (let ((o (make-overlay start (+ start len) nil t nil)))
-    (setq sp-show-pair-overlays (cons o nil))
+    (setq sp-show-pair-overlays (list o))
     (overlay-put o 'face 'sp-show-pair-mismatch-face)
     (overlay-put o 'priority 1000)
     (overlay-put o 'type 'show-pair)))
@@ -9424,10 +9432,8 @@ has been created."
 (defun sp-show--pair-delete-overlays ()
   "Remove both show pair overlays."
   (when sp-show-pair-overlays
-    (when (car sp-show-pair-overlays)
-      (delete-overlay (car sp-show-pair-overlays)))
-    (when (cdr sp-show-pair-overlays)
-      (delete-overlay (cdr sp-show-pair-overlays)))
+    (dolist (overlay sp-show-pair-overlays)
+      (delete-overlay overlay))
     (setq sp-show-pair-overlays nil)))
 
 (defun sp-show--pair-delete-enc-overlays ()


### PR DESCRIPTION
`paren` gives you an overlay that matches pairs and their content if you set its matching style to `expression`. `smartparens` doesn't support this matching style therefore there is no way to highlight the content of a pair.

In this PR I'm proposing a new customizable face `sp-show-pair-match-content-face` that will operate solely on the contents of a pair. 

This has an advantage over the `paren` implementation as `paren` is too rigid in that it doesn't allow you to highlight pairs and their contents independently.

Here's a look at a possible configuration
![kapture 2018-07-19 at 10 08 16](https://user-images.githubusercontent.com/644589/42933068-ca290358-8b3b-11e8-97f8-1edc37396304.gif)

And a working scenario (should have used a more visible colour for this example :D)
![kapture 2018-07-19 at 10 33 48](https://user-images.githubusercontent.com/644589/42934532-5e71e4fa-8b3f-11e8-992c-62a45fbc2eaf.gif)
