### PR TITLE
do not reindent fundamental-mode after kill

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -606,6 +606,7 @@ Symbol is defined as a chunk of text recognized by
                                              asm-mode
                                              makefile-gmake-mode
                                              haml-mode
+                                             fundamental-mode
                                              )
   "List of modes that should not reindent after kill."
   :type '(repeat symbol)


### PR DESCRIPTION
fundamental-mode looks kinda broken when using a simple `M-DEL`  (`sp-backward-kill-word` in strict mode).

It took me some time to figure this out and I think it's usually what average user might want.

WDYT?