### PR TITLE
Add support to avoid reindenting per indent-line-function

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -611,6 +611,14 @@ Symbol is defined as a chunk of text recognized by
   :type '(repeat symbol)
   :group 'smartparens)
 
+(defcustom sp-no-reindent-after-kill-indent-line-functions
+  '(
+    insert-tab
+    )
+  "List of `indent-line-function's that should not reindent after kill."
+  :type '(repeat symbol)
+  :group 'smartparens)
+
 (defvar sp--html-modes '(
                          sgml-mode
                          html-mode
@@ -6564,7 +6572,9 @@ Note: prefix argument is shown after the example in
       ;; less whitespace than there actually is because the indent
       ;; might further eat some up
       (indent-according-to-mode)
-    (unless (memq major-mode sp-no-reindent-after-kill-modes)
+    (unless (or (memq major-mode sp-no-reindent-after-kill-modes)
+                (memq indent-line-function
+                      sp-no-reindent-after-kill-indent-line-functions))
       (save-excursion
         (sp--indent-region (line-beginning-position) (line-end-position)))
       (when (> (save-excursion
@@ -7734,7 +7744,9 @@ represent a valid object in a buffer!"
           (let ((b (bounds-of-thing-at-point 'line)))
             (delete-region (car b) (cdr b))))
         (setq indent-from (point)))
-      (unless (memq major-mode sp-no-reindent-after-kill-modes)
+      (unless (or (memq major-mode sp-no-reindent-after-kill-modes)
+                  (memq indent-line-function
+                        sp-no-reindent-after-kill-indent-line-functions))
         (sp--keep-indentation
           (sp--indent-region indent-from indent-to))))))
 

--- a/test/smartparens-commands-test.el
+++ b/test/smartparens-commands-test.el
@@ -504,6 +504,15 @@ be."
     ("(-> (first (secord)))|" "(-> (first (|)))" "(-> (| ()))" "(| ( ()))")
     ("(-> |(first (secord)))" "(|(first (secord)))"))))
 
+;; #936
+(ert-deftest sp-test-command-sp-backward-delete-kill-word-obeys-indent-line-function ()
+  (sp-test-with-temp-buffer "foo\nbar baz|"
+      (progn
+        (smartparens-strict-mode 1)
+        (setq indent-line-function 'insert-tab))
+    (sp-backward-kill-word 1)
+    (sp-buffer-equals "foo\nbar |")))))
+
 (sp-test-command sp-kill-symbol
   ((nil
     ("|  'foo-bar-baz" "|")


### PR DESCRIPTION
Added sp-no-reindent-after-kill-indent-line-functions custom variable
which contains `indent-line-function's that shouldn't be reindented.