### PR TITLE
Add customizable behavior allowing backward-delete of blank sexps

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -1486,8 +1486,11 @@ kill \"subwords\" when `subword-mode' is active."
   :group 'smartparens)
 
 (defcustom sp-delete-blank-sexps nil
-  "If non-nil, allow deletion of enclosing pair when it only
-  contains whitespace."
+  "If non-nil, automatically delete enclosing pair when it only
+contains whitespace.
+
+This setting only has effect if `smartparens-strict-mode' is
+active."
   :type 'boolean
   :group 'smartparens)
 
@@ -1792,18 +1795,19 @@ If optional argument P is present test this instead of point."
 
 If optional argument P is present test this instead of point.
 
-Returns a cons containing the position of the beginning and end
-delimiters.
+If the sexp around the point is blank, the return value is a cons
+containing the beginning and end of the expression.
 
 Warning: it is only safe to call this when point is inside a
 sexp, otherwise the call may be very slow."
   (save-excursion
     (when p (goto-char p))
     (-when-let (enc (sp-get-enclosing-sexp))
-      (sp-get enc (when (string-match-p
-                         "\\`[ \t\n]*\\'"
-                         (buffer-substring-no-properties :beg-in :end-in))
-                    (cons :beg :end))))))
+      (sp-get enc
+        (when (string-match-p
+               "\\`[ \t\n]*\\'"
+               (buffer-substring-no-properties :beg-in :end-in))
+          (cons :beg :end))))))
 
 (defun sp-char-is-escaped-p (&optional point)
   "Test if the char at POINT is escaped or not.

--- a/test/smartparens-commands-test.el
+++ b/test/smartparens-commands-test.el
@@ -662,7 +662,10 @@ be."
   ((nil
     ("[foo]|" "[foo|]")
     ("\\{foo\\}|" "\\{foo|\\}")
-    ("\"foo\\\\\"|" "\"foo\\\\|\""))))
+    ("\"foo\\\\\"|" "\"foo\\\\|\"")
+    ("(|)" "|"))
+   (((sp-delete-blank-sexps t))
+    ("[|   ]" "|"))))
 
 (ert-deftest sp-test-command-sp-backward-delete-char-hungry-delete-mode ()
   "In `hungry-delete-mode' we should kill all whitespace."


### PR DESCRIPTION
This allows deleting empty sexps not only when they are completely empty (closing delimiter follows immediately after opening delimiter), but also if they only consist of white-space.

This is useful for modes where white-space is mandatory after/before delimiters, to get the same behavior for deleting empty sexps.

This also changes the return value of `sp-point-in-blank-sexp` to
return the beginning and ending positions of the enclosing regexp.