### PR TITLE
set :end correctly when no next sexp in sp-get-hybrid-sexp

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -5084,8 +5084,12 @@ See `sp-get-hybrid-sexp' for definition."
             (le (line-end-position))
             (cur (--if-let (save-excursion (sp-forward-sexp)) it (list :beg (1+ (point-max))))) ;hack
             last)
-        (if (> (sp-get cur :beg) le)
-            (if (sp-point-in-blank-line) le (skip-prefix-backward le))
+        (if (sp-get cur (or (< :beg p) (> :beg le)))
+            ;; if next sexp began after line end or there wasn't one (in which
+            ;; case we got parent sexp, which began before point) then return
+            ;; up to line end (or end of parent sexp, if it is before line end)
+            (if (sp-point-in-blank-line) le
+              (skip-prefix-backward (min le (1- (sp-get cur :end)))))
           (while (sp-get cur
                    (and cur
                         (< :beg le)


### PR DESCRIPTION
This seems to work for me.

The logic is that when `sp-forward-sexp` (in `sp--get-hybrid-sexp-end`) returns a next sexp whose `:beg` is before point, it must be because there are no more and it returned the parent sexp. And so, when `:beg` < point, either the end of the line or the end of the parent sexp, whichever is sooner.