### PR TITLE
Integration of smartparens with c/cpp-mode

### DIFF
--- a/smartparens-c.el
+++ b/smartparens-c.el
@@ -1,0 +1,52 @@
+;;; smartparens-c.el --- Additional configuration for C/C++ mode.  -*- lexical-binding: t; -*-
+;;
+;; Author: Naoya Yamashita <conao3@gmail.com>
+;; Maintainer: Matus Goljer <matus.goljer@gmail.com>
+;; Created: 23 June 2019
+;; Keywords: abbrev convenience editing
+;; URL: https://github.com/Fuco1/smartparens
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License:
+;;
+;; This file is part of Smartparens.
+;;
+;; Smartparens is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; Smartparens is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with Smartparens.  If not, see <http://www.gnu.org/licenses/>.
+;;
+;;; Commentary:
+;;
+;; This file provides some additional configuration for C/C++ mode.
+;; To use it, simply add:
+;;
+;; (require 'smartparens-c)
+;;
+;; into your configuration.  You can use this in conjunction with the
+;; default config or your own configuration.
+;;
+;;; Code:
+
+(require 'smartparens)
+
+;; remap electric delete functions to smartparens function
+(define-key smartparens-strict-mode-map [remap c-electric-delete-forward] 'sp-delete-char)
+(define-key smartparens-strict-mode-map [remap c-electric-backspace] 'sp-backward-delete-char)
+
+(sp-with-modes sp-c-modes
+  (sp-local-pair "{" nil :post-handlers '(("||\n[i]" "RET")))
+  (sp-local-pair "/*" "*/" :post-handlers '((" | " "SPC")
+                                            ("* ||\n[i]" "RET"))))
+
+(provide 'smartparens-c)
+;;; smartparens-c.el ends here

--- a/smartparens-config.el
+++ b/smartparens-config.el
@@ -101,6 +101,8 @@ ID, ACTION, CONTEXT."
 ;; automatically.  If you want to call sp-local-pair outside this
 ;; macro, you MUST supply the major mode argument.
 
+(--each sp-c-modes
+  (eval-after-load it                      '(require 'smartparens-c)))
 (eval-after-load 'clojure-mode             '(require 'smartparens-clojure))
 (eval-after-load 'crystal-mode             '(require 'smartparens-crystal))
 (eval-after-load 'elixir-mode              '(require 'smartparens-elixir))

--- a/smartparens.el
+++ b/smartparens.el
@@ -610,6 +610,14 @@ Symbol is defined as a chunk of text recognized by
   :type '(repeat symbol)
   :group 'smartparens)
 
+(defcustom sp-c-modes '(
+                        c-mode
+                        c++-mode
+                        )
+  "List of C-related modes."
+  :type '(repeat symbol)
+  :group 'smartparens)
+
 (defcustom sp-no-reindent-after-kill-modes '(
                                              python-mode
                                              coffee-mode


### PR DESCRIPTION
I noticed that even though C is a major language, there is no specific configuration file.

For example, when I'm using `smartparens-strict-mode`, the `c-electric-backspace` is not remapped, which clears the closing parentheses despite `smartparens-strict-mode`.

I looked at below site and added the minimum necessary settings.
Of course, not all the pairs needed to edit C's files have been added, but having the files will make it easier for someone else to edit them.

I wrote `smartparens-c` based on `smartparens-clojure`, but if it violates the policy, please let me know. I'll modify.

ref: https://tuhdo.github.io/c-ide.html#orgheadline56

Or there may be another reason for not having a C specific configuration file. I am sorry in that case. Please close it.