### PR TITLE
added bounds check to sp-skip-into-string

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -7570,9 +7570,9 @@ Examples:
 
 With BACK non-nil, move backwards."
   (if back
-      (while (not (sp-point-in-string))
+      (while (and (not (sp-point-in-string)) (> (point) (point-min)))
         (backward-char))
-    (while (not (sp-point-in-string))
+    (while (and (not (sp-point-in-string)) (< (point) (point-max)))
       (forward-char))))
 
 ;; TODO: in ruby, "foo |if bar" now moves correctly, but there's a


### PR DESCRIPTION
When a string is not properly formed, `sp-skip-into-string` can attempt to `(forward-char)` passed the end of the buffer.

E.g., with `point` at the beginning of the comment line in the following Lua code, eval `(sp-skip-into-string)` and you get an "End of buffer" error...

```lua
function foo()
  -- point here
  call_something()
  -- this comment contains what looks like a string's delimiter
  more code()
end
```

Perhaps this is because the `--` isn't recognised as a comment delimiter? I don't know. But a bounds-check in `sp-skip-into-string` seems appropriate nonetheless.