### PR TITLE
fix linter warnings and some headers

### DIFF
--- a/smartparens-c.el
+++ b/smartparens-c.el
@@ -1,40 +1,44 @@
-;;; smartparens-c.el --- Additional configuration for C/C++ mode.  -*- lexical-binding: t; -*-
-;;
+;;; smartparens-c.el --- Additional configuration for C/C++ mode  -*- lexical-binding: t; -*-
+
 ;; Author: Naoya Yamashita <conao3@gmail.com>
 ;; Maintainer: Matus Goljer <matus.goljer@gmail.com>
 ;; Created: 23 June 2019
-;; Keywords: abbrev convenience editing
-;; URL: https://github.com/Fuco1/smartparens
-;;
+
 ;; This file is not part of GNU Emacs.
-;;
+
 ;;; License:
-;;
+
 ;; This file is part of Smartparens.
-;;
+
 ;; Smartparens is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
-;;
+
 ;; Smartparens is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
-;;
+
 ;; You should have received a copy of the GNU General Public License
 ;; along with Smartparens.  If not, see <http://www.gnu.org/licenses/>.
-;;
+
 ;;; Commentary:
-;;
-;; This file provides some additional configuration for C/C++ mode.
-;; To use it, simply add:
-;;
+
+;; This file provides some additional configuration for C/C++ based
+;; modes.  To use it, simply add:
+
 ;; (require 'smartparens-c)
-;;
+
 ;; into your configuration.  You can use this in conjunction with the
 ;; default config or your own configuration.
-;;
+
+;; If you have good ideas about what should be added please file an
+;; issue on the github tracker.
+
+;; For more info, see github readme at
+;; https://github.com/Fuco1/smartparens
+
 ;;; Code:
 
 (require 'smartparens)

--- a/smartparens-clojure.el
+++ b/smartparens-clojure.el
@@ -1,40 +1,44 @@
-;;; smartparens-clojure.el --- Additional configuration for Clojure mode.  -*- lexical-binding: t; -*-
-;;
+;;; smartparens-clojure.el --- Additional configuration for Clojure mode  -*- lexical-binding: t; -*-
+
 ;; Author: Vitalie Spinu <spinuvit@gmail.com>
 ;; Maintainer: Matus Goljer <matus.goljer@gmail.com>
 ;; Created: 14 July 2016
-;; Keywords: abbrev convenience editing
-;; URL: https://github.com/Fuco1/smartparens
-;;
+
 ;; This file is not part of GNU Emacs.
-;;
+
 ;;; License:
-;;
+
 ;; This file is part of Smartparens.
-;;
+
 ;; Smartparens is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
-;;
+
 ;; Smartparens is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
-;;
+
 ;; You should have received a copy of the GNU General Public License
 ;; along with Smartparens.  If not, see <http://www.gnu.org/licenses/>.
-;;
+
 ;;; Commentary:
-;;
-;; This file provides some additional configuration for Clojure mode.  To use
-;; it, simply add:
-;;
+
+;; This file provides some additional configuration for clojure based
+;; modes.  To use it, simply add:
+
 ;; (require 'smartparens-clojure)
-;;
+
 ;; into your configuration.  You can use this in conjunction with the
 ;; default config or your own configuration.
-;;
+
+;; If you have good ideas about what should be added please file an
+;; issue on the github tracker.
+
+;; For more info, see github readme at
+;; https://github.com/Fuco1/smartparens
+
 ;;; Code:
 
 (require 'smartparens)

--- a/smartparens-config.el
+++ b/smartparens-config.el
@@ -5,8 +5,6 @@
 ;; Author: Matus Goljer <matus.goljer@gmail.com>
 ;; Maintainer: Matus Goljer <matus.goljer@gmail.com>
 ;; Created: 30 Jan 2013
-;; Keywords: abbrev convenience editing
-;; URL: https://github.com/Fuco1/smartparens
 
 ;; This file is not part of GNU Emacs.
 

--- a/smartparens-crystal.el
+++ b/smartparens-crystal.el
@@ -1,12 +1,10 @@
-;;; smartparens-crystal.el --- Additional configuration for Crystal based modes.  -*- lexical-binding: t; -*-
+;;; smartparens-crystal.el --- Additional configuration for Crystal based modes  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2018 Brantou
 
 ;; Author: Brantou <brantou89@gmail.com>
 ;; Maintainer: Brantou <brantou89@gmail.com>
 ;; Created: 5 March 2018
-;; Keywords: abbrev convenience editing
-;; URL: https://github.com/Fuco1/smartparens
 
 ;; Based on smartparens-ruby.el
 
@@ -33,12 +31,11 @@
 
 ;; This file provides some additional configuration for Crystal based
 ;; modes.  To use it, simply add:
-;;
+
 ;; (require 'smartparens-crystal)
-;;
+
 ;; into your configuration.  You can use this in conjunction with the
 ;; default config or your own configuration.
-;;
 
 ;; If you have good ideas about what should be added please file an
 ;; issue on the github tracker.

--- a/smartparens-elixir.el
+++ b/smartparens-elixir.el
@@ -1,27 +1,46 @@
-;;; smartparens-elixir.el --- Configuration for Elixir.  -*- lexical-binding: t; -*-
+;;; smartparens-elixir.el --- Additional configuration for Elixir based modes  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2017 Matúš Goljer
 
 ;; Author: Matúš Goljer <matus.goljer@gmail.com>
 ;; Maintainer: Matúš Goljer <matus.goljer@gmail.com>
-;; Version: 0.0.1
 ;; Created: 15th January 2017
-;; Keywords: languages
 
-;; This program is free software; you can redistribute it and/or
-;; modify it under the terms of the GNU General Public License
-;; as published by the Free Software Foundation; either version 3
-;; of the License, or (at your option) any later version.
+;; This file is not part of GNU Emacs.
 
-;; This program is distributed in the hope that it will be useful,
+;;; License:
+
+;; This file is part of Smartparens.
+
+;; Smartparens is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; Smartparens is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
 
 ;; You should have received a copy of the GNU General Public License
-;; along with this program. If not, see <http://www.gnu.org/licenses/>.
+;; along with Smartparens.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
+
+;; This file provides some additional configuration for elixir
+;; based modes.  To use it, simply add:
+
+;; (require 'smartparens-elixir)
+
+;; into your configuration.  You can use this in conjunction with the
+;; default config or your own configuration.
+
+;; If you have good ideas about what should be added please file an
+;; issue on the github tracker.
+
+;; For more info, see github readme at
+;; https://github.com/Fuco1/smartparens
+
 
 ;;; Code:
 

--- a/smartparens-ess.el
+++ b/smartparens-ess.el
@@ -1,39 +1,46 @@
-;;; smartparens-ess.el --- Smartparens Extension for Emacs Speaks Statistics  -*- lexical-binding: t; -*-
+;;; smartparens-ess.el --- Additional configuration for Emacs Speaks Statistics  -*- lexical-binding: t; -*-
 
 ;; Copyright (c) 2015-2016 Bernhard Pröll
 
 ;; Author: Bernhard Pröll
 ;; Maintainer: Bernhard Pröll
-;; URL: https://github.com/Fuco1/smartparens
-;; Created: 2015-02-26
-;; Version: 0.2
-;; Keywords: abbrev convenience editing
+;; Created: 6 Feb 2015
 
-;; This file is NOT part of GNU Emacs.
+;; This file is not part of GNU Emacs.
 
-;; This program is free software; you can redistribute it and/or modify
+;;; License:
+
+;; This file is part of Smartparens.
+
+;; Smartparens is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
 
-;; This program is distributed in the hope that it will be useful,
+;; Smartparens is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
 
 ;; You should have received a copy of the GNU General Public License
-;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;; along with Smartparens.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;
+
 ;; This file provides some additional configuration for ESS.  To use
 ;; it, simply add:
-;;
+
 ;; (require 'smartparens-ess)
-;;
+
 ;; into your configuration.  You can use this in conjunction with the
 ;; default config or your own configuration.
-;;
+
+;; If you have good ideas about what should be added please file an
+;; issue on the github tracker.
+
+;; For more info, see github readme at
+;; https://github.com/Fuco1/smartparens
+
 ;;; Code:
 
 (require 'smartparens)

--- a/smartparens-haskell.el
+++ b/smartparens-haskell.el
@@ -1,12 +1,10 @@
-;;; smartparens-haskell.el --- Additional configuration for Haskell based modes.  -*- lexical-binding: t; -*-
+;;; smartparens-haskell.el --- Additional configuration for Haskell based modes  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2015 Michael Xavier
 
 ;; Author: Michael Xavier <michael@michaelxavier.net>
 ;; Maintainer: Michael Xavier <michael@michaelxavier.net>
 ;; Created: 29 Apr 2016
-;; Keywords: abbrev convenience editing
-;; URL: https://github.com/Fuco1/smartparens
 
 ;; This file is not part of GNU Emacs.
 
@@ -31,9 +29,9 @@
 
 ;; This file provides some additional configuration for Haskell based
 ;; modes.  To use it, simply add:
-;;
+
 ;; (require 'smartparens-haskell)
-;;
+
 ;; into your configuration.  You can use this in conjunction with the
 ;; default config or your own configuration.
 

--- a/smartparens-html.el
+++ b/smartparens-html.el
@@ -1,12 +1,10 @@
-;;; smartparens-html.el --- Additional configuration for HTML based modes.  -*- lexical-binding: t; -*-
+;;; smartparens-html.el --- Additional configuration for HTML based modes  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2013-2014 Matus Goljer
 
 ;; Author: Matus Goljer <matus.goljer@gmail.com>
 ;; Maintainer: Matus Goljer <matus.goljer@gmail.com>
 ;; Created: 14 Sep 2013
-;; Keywords: abbrev convenience editing
-;; URL: https://github.com/Fuco1/smartparens
 
 ;; This file is not part of GNU Emacs.
 
@@ -31,9 +29,9 @@
 
 ;; This file provides some additional configuration for HTML based
 ;; modes.  To use it, simply add:
-;;
+
 ;; (require 'smartparens-html)
-;;
+
 ;; into your configuration.  You can use this in conjunction with the
 ;; default config or your own configuration.
 
@@ -41,7 +39,7 @@
 
 ;; `sp-html-next-tag'     - Recommended binding: C-c C-f
 ;; `sp-html-previous-tag' - Recommended binding: C-c C-b
-;;
+
 ;; (These two bindings are used for navigation by tags forward or
 ;;  backward, but `sp-forward-sexp' already does that.)
 

--- a/smartparens-javascript.el
+++ b/smartparens-javascript.el
@@ -1,11 +1,10 @@
-;;; smartparens-javascript.el --- Additional configuration for JavaScript based modes.  -*- lexical-binding: t; -*-
+;;; smartparens-javascript.el --- Additional configuration for JavaScript based modes  -*- lexical-binding: t; -*-
 
 ;; Copyright (c) 2017 Marinin Tim
+
 ;; Author: Tim Marinin <mt@marinin.xyz>
 ;; Maintainer: Tim Marinin <mt@marinin.xyz>
-;; Created: 2017-03-03
-;; Keywords: abbrev convenience editing javascript
-;; URL: https://github.com/Fuco1/smartparens
+;; Created: 3 Mar 2017
 
 ;; This file is not part of GNU Emacs.
 
@@ -30,15 +29,15 @@
 
 ;; This file provides some additional configuration for JavaScript based
 ;; modes.  To use it, simply add:
-;;
+
 ;; (require 'smartparens-javascript)
-;;
+
 ;; into your configuration.  You can use this in conjunction with the
 ;; default config or your own configuration.
-;;
+
 ;; If you have good ideas about what should be added please file an
 ;; issue on the github tracker.
-;;
+
 ;; For more info, see github readme at
 ;; https://github.com/Fuco1/smartparens
 

--- a/smartparens-latex.el
+++ b/smartparens-latex.el
@@ -1,12 +1,10 @@
-;;; smartparens-latex.el --- Additional configuration for (La)TeX based modes.  -*- lexical-binding: t; -*-
+;;; smartparens-latex.el --- Additional configuration for (La)TeX based modes  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2013-2016 Matus Goljer
 
 ;; Author: Matus Goljer <matus.goljer@gmail.com>
 ;; Maintainer: Matus Goljer <matus.goljer@gmail.com>
 ;; Created: 14 Feb 2013
-;; Keywords: abbrev convenience editing
-;; URL: https://github.com/Fuco1/smartparens
 
 ;; This file is not part of GNU Emacs.
 
@@ -31,9 +29,9 @@
 
 ;; This file provides some additional configuration for (La)TeX based
 ;; modes.  To use it, simply add:
-;;
+
 ;; (require 'smartparens-latex)
-;;
+
 ;; into your configuration.  You can use this in conjunction with the
 ;; default config or your own configuration.
 

--- a/smartparens-lua.el
+++ b/smartparens-lua.el
@@ -1,12 +1,10 @@
-;;; smartparens-lua.el --- Additional configuration for Lua based modes.  -*- lexical-binding: t; -*-
+;;; smartparens-lua.el --- Additional configuration for Lua based modes  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2013-2014 Matus Goljer
 
 ;; Author: Matus Goljer <matus.goljer@gmail.com>
 ;; Maintainer: Matus Goljer <matus.goljer@gmail.com>
-;; Created: 3 August 2013
-;; Keywords: abbrev convenience editing
-;; URL: https://github.com/Fuco1/smartparens
+;; Created: 3 Aug 2013
 
 ;; This file is not part of GNU Emacs.
 
@@ -31,15 +29,15 @@
 
 ;; This file provides some additional configuration for Lua based
 ;; modes.  To use it, simply add:
-;;
+
 ;; (require 'smartparens-lua)
-;;
+
 ;; into your configuration.  You can use this in conjunction with the
 ;; default config or your own configuration.
-;;
+
 ;; If you have good ideas about what should be added please file an
 ;; issue on the github tracker.
-;;
+
 ;; For more info, see github readme at
 ;; https://github.com/Fuco1/smartparens
 

--- a/smartparens-markdown.el
+++ b/smartparens-markdown.el
@@ -1,12 +1,10 @@
-;;; smartparens-markdown.el --- Additional configuration for Markdown based modes.  -*- lexical-binding: t; -*-
+;;; smartparens-markdown.el --- Additional configuration for Markdown based modes  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2017 Matus Goljer
 
 ;; Author: Matus Goljer <matus.goljer@gmail.com>
 ;; Maintainer: Matus Goljer <matus.goljer@gmail.com>
-;; Created: 11th May 2017
-;; Keywords: abbrev convenience editing
-;; URL: https://github.com/Fuco1/smartparens
+;; Created: 11 May 2017
 
 ;; This file is not part of GNU Emacs.
 
@@ -31,15 +29,15 @@
 
 ;; This file provides some additional configuration for Markdown based
 ;; modes.  To use it, simply add:
-;;
+
 ;; (require 'smartparens-markdown)
-;;
+
 ;; into your configuration.  You can use this in conjunction with the
 ;; default config or your own configuration.
-;;
+
 ;; If you have good ideas about what should be added please file an
 ;; issue on the github tracker.
-;;
+
 ;; For more info, see github readme at
 ;; https://github.com/Fuco1/smartparens
 

--- a/smartparens-ml.el
+++ b/smartparens-ml.el
@@ -8,8 +8,6 @@
 ;;         Louis Roché <louis@louisroche.net>
 ;; Maintainer: Matus Goljer <matus.goljer@gmail.com>
 ;; Created: 14 July 2016
-;; Keywords: smartparens, ML, ocaml, reason
-;; URL: https://github.com/Fuco1/smartparens
 
 ;; This file is not part of GNU Emacs.
 
@@ -34,15 +32,15 @@
 
 ;; This file provides some additional configuration for ML languages.
 ;; To use it, simply add:
-;;
+
 ;; (require 'smartparens-ml)
-;;
+
 ;; into your configuration.  You can use this in conjunction with the
 ;; default config or your own configuration.
-;;
+
 ;; If you have good ideas about what should be added please file an
 ;; issue on the github tracker.
-;;
+
 ;; For more info, see github readme at
 ;; https://github.com/Fuco1/smartparens
 

--- a/smartparens-org.el
+++ b/smartparens-org.el
@@ -1,39 +1,43 @@
-;;; smartparens-org.el --- Configuration for Org mode.  -*- lexical-binding: t; -*-
+;;; smartparens-org.el --- Additional configuration for Org based modes  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2017 Matúš Goljer
 
 ;; Author: Matúš Goljer <matus.goljer@gmail.com>
 ;; Maintainer: Matúš Goljer <matus.goljer@gmail.com>
-;; Version: 0.0.1
-;; Created: 15th January 2017
-;; Keywords: languages
+;; Created: 15 Jan 2017
 
-;; This program is free software; you can redistribute it and/or
-;; modify it under the terms of the GNU General Public License
-;; as published by the Free Software Foundation; either version 3
-;; of the License, or (at your option) any later version.
+;; This file is not part of GNU Emacs.
 
-;; This program is distributed in the hope that it will be useful,
+;;; License:
+
+;; This file is part of Smartparens.
+
+;; Smartparens is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; Smartparens is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
 
 ;; You should have received a copy of the GNU General Public License
-;; along with this program. If not, see <http://www.gnu.org/licenses/>.
+;; along with Smartparens.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 
 ;; This file provides some additional configuration for Org based
 ;; modes.  To use it, simply add:
-;;
+
 ;; (require 'smartparens-org)
-;;
+
 ;; into your configuration.  You can use this in conjunction with the
 ;; default config or your own configuration.
-;;
+
 ;; If you have good ideas about what should be added please file an
 ;; issue on the github tracker.
-;;
+
 ;; For more info, see github readme at
 ;; https://github.com/Fuco1/smartparens
 

--- a/smartparens-python.el
+++ b/smartparens-python.el
@@ -1,12 +1,10 @@
-;;; smartparens-python.el --- Additional configuration for Python based modes.  -*- lexical-binding: t; -*-
+;;; smartparens-python.el --- Additional configuration for Python based modes  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2015-2016 Matus Goljer
 
 ;; Author: Matus Goljer <matus.goljer@gmail.com>
 ;; Maintainer: Matus Goljer <matus.goljer@gmail.com>
-;; Created: 8 February 2015
-;; Keywords: abbrev convenience editing
-;; URL: https://github.com/Fuco1/smartparens
+;; Created: 8 Feb 2015
 
 ;; This file is not part of GNU Emacs.
 
@@ -31,15 +29,15 @@
 
 ;; This file provides some additional configuration for Python based
 ;; modes.  To use it, simply add:
-;;
+
 ;; (require 'smartparens-python)
-;;
+
 ;; into your configuration.  You can use this in conjunction with the
 ;; default config or your own configuration.
-;;
+
 ;; If you have good ideas about what should be added please file an
 ;; issue on the github tracker.
-;;
+
 ;; For more info, see github readme at
 ;; https://github.com/Fuco1/smartparens
 

--- a/smartparens-racket.el
+++ b/smartparens-racket.el
@@ -1,12 +1,10 @@
-;;; smartparens-racket.el --- Additional configuration for Racket based modes.  -*- lexical-binding: t; -*-
+;;; smartparens-racket.el --- Additional configuration for Racket based modes  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2015 Vikraman Choudhury
 
 ;; Author: Vikraman Choudhury <git@vikraman.org>
 ;; Maintainer: Vikraman Choudhury <git@vikraman.org>
 ;; Created: 26 Oct 2015
-;; Keywords: abbrev convenience editing
-;; URL: https://github.com/Fuco1/smartparens
 
 ;; This file is not part of GNU Emacs.
 
@@ -31,15 +29,15 @@
 
 ;; This file provides some additional configuration for Racket based
 ;; modes.  To use it, simply add:
-;;
+
 ;; (require 'smartparens-racket)
-;;
+
 ;; into your configuration.  You can use this in conjunction with the
 ;; default config or your own configuration.
-;;
+
 ;; If you have good ideas about what should be added please file an
 ;; issue on the github tracker.
-;;
+
 ;; For more info, see github readme at
 ;; https://github.com/Fuco1/smartparens
 

--- a/smartparens-rst.el
+++ b/smartparens-rst.el
@@ -1,12 +1,10 @@
-;;; smartparens-rst.el --- Additional configuration for rst based modes.  -*- lexical-binding: t; -*-
+;;; smartparens-rst.el --- Additional configuration for rst based modes  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2019 Matus Goljer
 
 ;; Author: Matus Goljer <matus.goljer@gmail.com>
 ;; Maintainer: Matus Goljer <matus.goljer@gmail.com>
-;; Created: 28th January 2019
-;; Keywords: abbrev convenience editing
-;; URL: https://github.com/Fuco1/smartparens
+;; Created: 28 January 2019
 
 ;; This file is not part of GNU Emacs.
 
@@ -31,15 +29,15 @@
 
 ;; This file provides some additional configuration for rst based
 ;; modes.  To use it, simply add:
-;;
+
 ;; (require 'smartparens-rst)
-;;
+
 ;; into your configuration.  You can use this in conjunction with the
 ;; default config or your own configuration.
-;;
+
 ;; If you have good ideas about what should be added please file an
 ;; issue on the github tracker.
-;;
+
 ;; For more info, see github readme at
 ;; https://github.com/Fuco1/smartparens
 

--- a/smartparens-ruby.el
+++ b/smartparens-ruby.el
@@ -1,12 +1,10 @@
-;;; smartparens-ruby.el --- Additional configuration for Ruby based modes.  -*- lexical-binding: t; -*-
+;;; smartparens-ruby.el --- Additional configuration for Ruby based modes  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2013-2014 Jean-Louis Giordano
 
 ;; Author: Jean-Louis Giordano <jean-louis@jawaninja.com>
 ;; Maintainer: Matus Goljer <matus.goljer@gmail.com>
 ;; Created: 16 June 2013
-;; Keywords: abbrev convenience editing
-;; URL: https://github.com/Fuco1/smartparens
 
 ;; This file is not part of GNU Emacs.
 
@@ -31,12 +29,11 @@
 
 ;; This file provides some additional configuration for Ruby based
 ;; modes.  To use it, simply add:
-;;
+
 ;; (require 'smartparens-ruby)
-;;
+
 ;; into your configuration.  You can use this in conjunction with the
 ;; default config or your own configuration.
-;;
 
 ;; If you have good ideas about what should be added please file an
 ;; issue on the github tracker.

--- a/smartparens-rust.el
+++ b/smartparens-rust.el
@@ -1,10 +1,10 @@
-;;; smartparens-rust.el --- Additional configuration for Rust based modes.  -*- lexical-binding: t; -*-
+;;; smartparens-rust.el --- Additional configuration for Rust based modes  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2015 Wilfred Hughes
 
-;; Created: 3 November 2015
-;; Keywords: abbrev convenience editing
-;; URL: https://github.com/Fuco1/smartparens
+;; Author: Wilfred Hughes
+;; Maintainer: Matus Goljer <matus.goljer@gmail.com>
+;; Created: 3 Nov 2015
 
 ;; This file is not part of GNU Emacs.
 
@@ -27,19 +27,24 @@
 
 ;;; Commentary:
 
-;; This file provides some additional configuration for Rust.  To use
-;; it, simply add:
-;;
+;; This file provides some additional configuration for Rust based
+;; modes.  To use it, simply add:
+
 ;; (require 'smartparens-config)
-;;
+
 ;; alternatively, you can explicitly load these preferences:
-;;
+
 ;; (require 'smartparens-rust)
-;;
-;; in your configuration.
+
+;; into your configuration.  You can use this in conjunction with the
+;; default config or your own configuration.
+
+;; If you have good ideas about what should be added please file an
+;; issue on the github tracker.
 
 ;; For more info, see github readme at
 ;; https://github.com/Fuco1/smartparens
+
 
 ;;; Code:
 (require 'smartparens)

--- a/smartparens-scala.el
+++ b/smartparens-scala.el
@@ -1,12 +1,10 @@
-;;; smartparens-scala.el --- Additional configuration for Scala based modes.  -*- lexical-binding: t; -*-
+;;; smartparens-scala.el --- Additional configuration for Scala based modes  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2015 Greg Nwosu
 
 ;; Author: Greg Nwosu <greg.nwosu@gmail.com>
 ;; Maintainer: Greg Nwosu <greg.nwosu@gmail.com>
 ;; Created: 8 July 2015
-;; Keywords: abbrev convenience editing
-;; URL: https://github.com/Fuco1/smartparens
 
 ;; This file is not part of GNU Emacs.
 
@@ -31,15 +29,15 @@
 
 ;; This file provides some additional configuration for Scala based
 ;; modes.  To use it, simply add:
-;;
+
 ;; (require 'smartparens-scala)
-;;
+
 ;; into your configuration.  You can use this in conjunction with the
 ;; default config or your own configuration.
-;;
+
 ;; If you have good ideas about what should be added please file an
 ;; issue on the github tracker.
-;;
+
 ;; For more info, see github readme at
 ;; https://github.com/Fuco1/smartparens
 

--- a/smartparens-text.el
+++ b/smartparens-text.el
@@ -1,12 +1,10 @@
-;;; smartparens-latex.el --- Additional configuration for text-mode.  -*- lexical-binding: t; -*-
+;;; smartparens-latex.el --- Additional configuration for text-mode  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2017 Matus Goljer
 
 ;; Author: Matus Goljer <matus.goljer@gmail.com>
 ;; Maintainer: Matus Goljer <matus.goljer@gmail.com>
 ;; Created: 16 July 2017
-;; Keywords: abbrev convenience editing
-;; URL: https://github.com/Fuco1/smartparens
 
 ;; This file is not part of GNU Emacs.
 
@@ -31,9 +29,9 @@
 
 ;; This file provides some additional configuration for `text-mode'.
 ;; To use it, simply add:
-;;
+
 ;; (require 'smartparens-text)
-;;
+
 ;; into your configuration.  You can use this in conjunction with the
 ;; default config or your own configuration.
 

--- a/smartparens.el
+++ b/smartparens.el
@@ -3331,8 +3331,8 @@ extra boundary conditions depending on parens."
     (sp--wrap-regexp (regexp-opt strings) start end)))
 
 (defun sp--strict-regexp-opt (strings &optional ignored)
-  "Like regexp-opt, but with extra boundary conditions to ensure
-that the strings are not matched in-symbol."
+  "Like `regexp-opt', but with extra boundary conditions to ensure
+that the STRINGS are not matched in-symbol."
   (if strings
       (with-syntax-table
           ;; HACK: this is a terrible hack to make ' be treated as a
@@ -3351,7 +3351,7 @@ that the strings are not matched in-symbol."
     "^\\<$"))
 
 (defun sp--strict-regexp-quote (string)
-  "Like regexp-quote, but make sure that the string is not
+  "Like `regexp-quote', but make sure that the STRING is not
 matched in-symbol."
   (sp--wrap-regexp (regexp-quote string)
                    (string-match-p "\\`\\<" string)
@@ -4262,12 +4262,12 @@ is remove the just added wrapping."
     (looking-at-p regexp)))
 
 (defun sp--looking-back (regexp &optional limit not-greedy)
-  "Return non-nil if text before point matches regular expression REGEXP.
+  "Return non-nil if text before point matche regular expression REGEXP.
 
 With optional argument LIMIT search only that many characters
 backward.  If LIMIT is nil, default to `sp-max-pair-length'.
 
-If optional argument NON-GREEDY is t search for any matching
+If optional argument NOT-GREEDY is t search for any matching
 sequence, not necessarily the longest possible."
   (setq limit (or limit sp-max-pair-length))
   (sp--with-case-sensitive
@@ -4297,7 +4297,7 @@ sequence, not necessarily the longest possible."
     (sp--looking-back regexp limit not-greedy)))
 
 (defun sp--search-backward-regexp (regexp &optional bound noerror count)
-  "Works just like `search-backward-regexp', but returns the
+  "Works just like `search-backward-regexp', but return the
 longest possible match.  That means that searching for
 \"defun|fun\" backwards would return \"defun\" instead of
 \"fun\", which would be matched first.
@@ -4464,7 +4464,7 @@ be a function call that sets the match data."
                   :pair-skip ,pair-skip))))))
 
 (defun sp--elisp-skip-match (ms mb _me)
-  "Function used to test for escapes in lisp modes.
+  "Function used to test for escapes in Lisp modes.
 
 Non-nil return value means to skip the result."
   (and ms
@@ -4759,7 +4759,7 @@ opening and closing delimiter, such as *...*, \"...\", `...` etc."
               (list :beg b :end e :op m :cl m :prefix (sp--get-prefix b m) :suffix (sp--get-suffix e m)))))))))
 
 (defun sp--textmode-stringlike-regexp (delimiters &optional direction)
-  "Get a regexp matching text-mode string-like DELIMITERS.
+  "Get a regexp matching `text-mode' string-like DELIMITERS.
 
 Capture group 1 or 2 has the delimiter itself, depending on the
 direction (forward, backward).
@@ -4797,7 +4797,7 @@ and the skip-match predicate."
     hit))
 
 (defun sp-get-textmode-stringlike-expression (&optional back)
-  "Find the nearest text-mode string-like expression.
+  "Find the nearest `text-mode' string-like expression.
 
 If BACK is non-nil search in the backwards direction.
 
@@ -5401,7 +5401,7 @@ and newline."
   (not (equal "/" (substring tag 1 2))))
 
 (defun sp--sgml-ignore-tag (tag)
-  "Return non-nil if tag should be ignored in search, nil otherwise."
+  "Return non-nil if TAG should be ignored in search, nil otherwise."
   (member tag '("!--" "!DOCTYPE")))
 
 (defun sp-get-sgml-tag (&optional back)
@@ -5523,13 +5523,13 @@ the pairs for easier navigation of blocks in C-like languages."
 
 ;; TODO: add shorter alias?
 (defun sp-restrict-to-pairs-interactive (pairs function)
-  "Return an interactive lambda that calls FUNCTION restricted to PAIRS.
+  "Return an interactive lambda that call FUNCTION restricted to PAIRS.
 
 See `sp-restrict-to-pairs'.
 
 This function implements a \"decorator pattern\", that is, you
 can apply another scoping function to the output of this function
-and the effects will added together. In particular, you can
+and the effects will added together.  In particular, you can
 combine it with:
 
 - `sp-restrict-to-object-interactive'
@@ -5545,7 +5545,7 @@ ignoring all others."
     (sp-restrict-to-pairs pairs function)))
 
 (defun sp-restrict-to-object-interactive (object function)
-  "Return an interactive lambda that calls FUNCTION restricted to OBJECT.
+  "Return an interactive lambda that call FUNCTION restricted to OBJECT.
 
 See `sp-restrict-to-object'.
 
@@ -5571,7 +5571,7 @@ expressions, ignoring strings and sgml tags."
 (defun sp-prefix-tag-object (&optional _arg)
   "Read the command and invoke it on the next tag object.
 
-If you specify a regular emacs prefix argument this is passed to
+If you specify a regular Emacs prefix argument this is passed to
 the executed command.  Therefore, executing
 \"\\[universal-argument] 2 \\[sp-prefix-tag-object] \\[sp-forward-sexp]\" will move two tag
 expressions forward, ignoring possible symbols or paired
@@ -5589,7 +5589,7 @@ Tag object is anything delimited by sgml tag."
 (defun sp-prefix-pair-object (&optional _arg)
   "Read the command and invoke it on the next pair object.
 
-If you specify a regular emacs prefix argument this is passed to
+If you specify a regular Emacs prefix argument this is passed to
 the executed command.  Therefore, executing
 \"\\[universal-argument] 2 \\[sp-prefix-pair-object] \\[sp-forward-sexp]\" will move two paired
 expressions forward, ignoring possible symbols inbetween.
@@ -5606,7 +5606,7 @@ Pair object is anything delimited by pairs from `sp-pair-list'."
 (defun sp-prefix-symbol-object (&optional _arg)
   "Read the command and invoke it on the next pair object.
 
-If you specify a regular emacs prefix argument this is passed to
+If you specify a regular Emacs prefix argument this is passed to
 the executed command.  Therefore, executing
 \"\\[universal-argument] 2 \\[sp-prefix-symbol-object] \\[sp-forward-sexp]\" will move two symbols
 forward, ignoring any structure.
@@ -5624,7 +5624,7 @@ Symbol is defined as a chunk of text recognized by
 (defun sp-prefix-save-excursion (&optional _arg)
   "Execute the command keeping the point fixed.
 
-If you specify a regular emacs prefix argument this is passed to
+If you specify a regular Emacs prefix argument this is passed to
 the executed command."
   (interactive "P")
   (let* ((cmd (read-key-sequence "" t))
@@ -5777,7 +5777,7 @@ expressions are considered."
 
 (defun sp-narrow-to-sexp (arg)
   "Make text outside current balanced expression invisible.
-A numeric arg specifies to move up by that many enclosing expressions.
+A numeric ARG specifies to move up by that many enclosing expressions.
 
 See also `narrow-to-region' and `narrow-to-defun'."
   (interactive "p")
@@ -6344,7 +6344,7 @@ move backward but still to a less deep spot.
 The argument INTERACTIVE is for internal use only.
 
 If called interactively and `sp-navigate-reindent-after-up' is
-enabled for current major-mode, remove the whitespace between end
+enabled for current `major-mode', remove the whitespace between end
 of the expression and the last \"thing\" inside the expression.
 This behaviour can be suppressed for syntactic string sexps by
 setting `sp-navigate-reindent-after-up-in-string' to nil.
@@ -6442,7 +6442,7 @@ move forward but still to a less deep spot.
 The argument INTERACTIVE is for internal use only.
 
 If called interactively and `sp-navigate-reindent-after-up' is
-enabled for current major-mode, remove the whitespace between
+enabled for current `major-mode', remove the whitespace between
 beginning of the expression and the first \"thing\" inside the
 expression.
 
@@ -6663,7 +6663,7 @@ Examples:
   (sp-kill-sexp (sp--negate-argument arg) dont-kill))
 
 (defun sp-copy-sexp (&optional arg)
-  "Copy the following ARG expressions to the kill-ring.
+  "Copy the following ARG expressions to the `kill-ring'.
 
 This is exactly like calling `sp-kill-sexp' with second argument
 t.  All the special prefix arguments work the same way."
@@ -6672,7 +6672,7 @@ t.  All the special prefix arguments work the same way."
     (sp-kill-sexp arg t)))
 
 (defun sp-backward-copy-sexp (&optional arg)
-  "Copy the previous ARG expressions to the kill-ring.
+  "Copy the previous ARG expressions to the `kill-ring'.
 
 This is exactly like calling `sp-backward-kill-sexp' with second argument
 t.  All the special prefix arguments work the same way."
@@ -6816,8 +6816,7 @@ Examples:
       (kill-whole-line))))
 
 (defun sp--transpose-objects (first second)
-  "Transpose FIRST and SECOND object while preserving the
-whitespace between them."
+  "Transpose FIRST and SECOND object while preserving the whitespace between them."
   (save-excursion
     (goto-char (sp-get second :beg-prf))
     (let ((ins (sp-get second (delete-and-extract-region :beg-prf :end)))
@@ -6831,10 +6830,10 @@ whitespace between them."
 The operation will move the point after the transposed block, so
 the next transpose will \"drag\" it forward.
 
-With arg positive N, apply that many times, dragging the
+With ARG positive N, apply that many times, dragging the
 expression forward.
 
-With arg negative -N, apply N times backward, pushing the word
+With ARG negative -N, apply N times backward, pushing the word
 before cursor backward.  This will therefore not transpose the
 expressions before and after point, but push the expression
 before point over the one before it.
@@ -6934,10 +6933,12 @@ Examples:
 ;; package available at
 ;; http://elpa.gnu.org/packages/adjust-parens-1.0.el
 (defun sp-indent-adjust-sexp ()
-  "Add the hybrid sexp at line into previous sexp.  All forms
-between the two are also inserted.  Specifically, if the point is
-on empty line, move the closing delimiter there, so the next
-typed text will become the last item of the previous sexp.
+  "Add the hybrid sexp at line into previous sexp.
+
+All forms between the two are also inserted.  Specifically, if
+the point is on empty line, move the closing delimiter there, so
+the next typed text will become the last item of the previous
+sexp.
 
 This acts similarly to `sp-add-to-previous-sexp' but with special
 handling of empty lines."
@@ -6960,11 +6961,12 @@ handling of empty lines."
       (sp--run-hook-with-args (sp-get prev-sexp :op) :post-handlers 'indent-adjust-sexp))))
 
 (defun sp-dedent-adjust-sexp ()
-  "Remove the hybrid sexp at line from previous sexp.  All
-sibling forms after it are also removed (not deleted, just placed
-outside of the enclosing list).  Specifically, if the point is on
-empty line followed by closing delimiter of enclosing list, move
-the closing delimiter after the last item in the list.
+  "Remove the hybrid sexp at line from previous sexp.
+
+All sibling forms after it are also removed (not deleted, just
+placed outside of the enclosing list).  Specifically, if the
+point is on empty line followed by closing delimiter of enclosing
+list, move the closing delimiter after the last item in the list.
 
 This acts similarly to `sp-forward-barf-sexp' but with special
 handling of empty lines."
@@ -7749,7 +7751,7 @@ Examples:
 (defun sp-swap-enclosing-sexp (&optional arg)
   "Swap the enclosing delimiters of this and the parent expression.
 
-With N > 0 numeric argument, ascend that many levels before
+With ARG > 0 numeric argument, ascend that many levels before
 swapping.
 
 Examples:
@@ -7931,7 +7933,7 @@ Examples:
   "Save the text in the region between BEG and END inside EXPR,
 then delete EXPR and insert the saved text.
 
-If optional argument JUPM-END is equal to the symbol 'end move
+If optional argument JUMP-END is equal to the symbol 'end move
 the point after the re-inserted text."
   (let (str p)
     (setq str (buffer-substring-no-properties beg end))
@@ -8921,7 +8923,7 @@ Examples:
 (put 'sp-delete-char 'delete-selection 'supersede)
 
 (defun sp-point-in-empty-sexp (&optional pos)
-  "Return non-nil if point is in empty sexp or string.
+  "Return non-nil if POS is in empty sexp or string.
 
 The return value is active cons pair of opening and closing sexp
 delimiter enclosing this sexp."
@@ -8935,7 +8937,7 @@ delimiter enclosing this sexp."
      ((sp-point-in-empty-string pos)))))
 
 (defun sp-point-in-empty-string (&optional pos)
-  "Return non-nil if point is in empty string.
+  "Return non-nil if POS is in empty string.
 
 The return value is actually cons pair of opening and closing
 string delimiter enclosing this string."
@@ -9227,7 +9229,7 @@ comment."
 
 (defun sp-comment ()
   "Insert the comment character and adjust hanging sexps such
-  that it doesn't break structure."
+that it doesn't break structure."
   (interactive)
   (if (sp-point-in-string-or-comment)
       (if (= 1 (length (single-key-description last-command-event))) ;; pretty hacky
@@ -9486,7 +9488,7 @@ matching paren in the echo area if not visible on screen."
 
 (defun sp-show--pair-echo-match (start end olen clen)
   "Print the line of the matching paren in the echo area if not
-visible on screen. Needs to be called after the show-pair overlay
+visible on screen.  Needs to be called after the show-pair overlay
 has been created."
   (let ((match-positions (list start end olen clen)))
     (when (not (and (equal sp-show-pair-previous-match-positions match-positions)
@@ -9582,8 +9584,7 @@ has a pair definition.  If so, we insert the closing pair."
     (sp-insert-pair)))
 
 (defvar sp--mc/cursor-specific-vars
-  '(
-    sp-wrap-point
+  '(sp-wrap-point
     sp-wrap-mark
     sp-last-wrapped-region
     sp-pair-overlay-list

--- a/smartparens.el
+++ b/smartparens.el
@@ -1,4 +1,4 @@
-;;; smartparens.el --- Automatic insertion, wrapping and paredit-like navigation with user defined pairs. -*- lexical-binding: t -*-
+;;; smartparens.el --- Automatic insertion, wrapping and paredit-like navigation with user defined pairs  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2012-2016 Matus Goljer
 


### PR DESCRIPTION
Hi! I found many linter warnings so I try to solve them.
But many warnings remained.  I fix easy warnings only.

## Warnings

``` emacs-lisp
Lisp symbol ‘regexp-opt’ should appear in quotes (emacs-lisp-checkdoc)
Lisp symbol ‘regexp-quote’ should appear in quotes (emacs-lisp-checkdoc)
Lisp symbol ‘text-mode’ should appear in quotes (emacs-lisp-checkdoc)
Name lisp should appear capitalized as Lisp (emacs-lisp-checkdoc)
```

## Headers

Some headers wrote Created date as <year>-<mon>-<day> format. Follow smartparens.el.

Fix header comment to follow smartparens.el

Remove unneeded version/keyword/url comment header (should refer main smartparens.el).