### PR TITLE
Add configuration for Coq

### DIFF
--- a/smartparens-config.el
+++ b/smartparens-config.el
@@ -128,6 +128,7 @@ ID, ACTION, CONTEXT."
 (eval-after-load 'text-mode                '(require 'smartparens-text))
 (eval-after-load 'tuareg                   '(require 'smartparens-ml))
 (eval-after-load 'fsharp-mode              '(require 'smartparens-ml))
+(eval-after-load 'coq-mode                 '(require 'smartparens-ml))
 (--each '(js js2-mode)
   (eval-after-load it                      '(require 'smartparens-javascript)))
 (provide 'smartparens-config)

--- a/smartparens-ml.el
+++ b/smartparens-ml.el
@@ -55,6 +55,14 @@
 (sp-with-modes '(fsharp-mode)
   (sp-local-pair "(*" "*)" ))
 
+(sp-with-modes '(coq-mode)
+  ;; Disable ` because it is used in implicit generalization
+  (sp-local-pair "`" nil :actions nil)
+  (sp-local-pair "(*" "*)" :actions nil)
+  (sp-local-pair "(*" "*"
+                 :actions '(insert)
+                 :post-handlers '(("| " "SPC") ("|\n[i]*)[d-2]" "RET"))) )
+
 (sp-with-modes '(tuareg-mode)
   ;; Disable ` because it is used in polymorphic variants
   (sp-local-pair "`" nil :actions nil)


### PR DESCRIPTION
This is somewhat magical to me but it's copied from Doom Emacs' configuration for OCaml (tuareg-mode) and F# and it seems to work nicely: https://github.com/hlissner/doom-emacs/blob/1ab9f8b99d35a451a06c8278457ddfa58c566186/modules/config/default/config.el#L182.

I also tried `(sp-local-pair "(*" "*)")` but with that if you type `(*` you get `(**))`. It's quite possible that smartparens has this bug currently for OCaml and F#.