### PR TITLE
Fix feature name for C-like modes

### DIFF
--- a/smartparens-config.el
+++ b/smartparens-config.el
@@ -101,8 +101,7 @@ ID, ACTION, CONTEXT."
 ;; automatically.  If you want to call sp-local-pair outside this
 ;; macro, you MUST supply the major mode argument.
 
-(--each sp-c-modes
-  (eval-after-load it                      '(require 'smartparens-c)))
+(eval-after-load 'cc-mode                  '(require 'smartparens-c))
 (eval-after-load 'clojure-mode             '(require 'smartparens-clojure))
 (eval-after-load 'crystal-mode             '(require 'smartparens-crystal))
 (eval-after-load 'elixir-mode              '(require 'smartparens-elixir))


### PR DESCRIPTION
The feature that implements both c-mode and c++-mode is called
cc-mode. There are no standalone c-mode and c++-mode features.