### PR TITLE
Clarify sp-pair documentation

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -2289,7 +2289,10 @@ is wrapped instead.  This is useful with selection functions in
                    wrap
                    bind
                    insert)
-  "Add a pair definition.
+  "Add, remove or update a pair definition.
+
+The pair definition is removed if ACTIONS is :rem, added if it
+does not exist, and updated otherwise.
 
 OPEN is the opening delimiter.  Every pair is uniquely determined
 by this string.


### PR DESCRIPTION
The sp-pair function does not only add, but also remove or update pair
definitions. Make it immediately clear at the top of the
documentation. Later parts of the documentation refer to updating of
the definition and without mentioning that sp-pair can also update,
the documentation is confusing.