### PR TITLE
Use same function arguments for sp-kill-region as kill-region

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -9151,19 +9151,22 @@ With a prefix argument, skip the balance check."
     (setq this-command 'delete-region)
     (delete-region beg end)))
 
-(defun sp-kill-region (beg end)
+(defun sp-kill-region (beg end &optional region)
   "Kill the text between point and mark, like `kill-region'.
 
 BEG and END are the bounds of region to be killed.
 
 If that text is unbalanced, signal an error instead.
-With a prefix argument, skip the balance check."
+With a prefix argument, skip the balance check.
+
+If the optional argument REGION is non-nil, the function ignores
+BEG and END, and kills the current region instead."
   (interactive "r")
   (when (or current-prefix-arg
             (sp-region-ok-p beg end)
             (user-error (sp-message :unbalanced-region :return)))
     (setq this-command 'kill-region)
-    (kill-region beg end)))
+    (kill-region beg end region)))
 
 (defun sp-indent-defun (&optional arg)
   "Reindent the current defun.


### PR DESCRIPTION
Some packages like `whole-line-or-region` expect the same
function signature for `kill-region` kind of functions.

Now you can e.g. define

```emacs-lisp
  (defun whole-line-or-region-sp-kill-region (prefix)
    "Call `sp-kill-region' on region or PREFIX whole lines."
    (interactive "p")
    (whole-line-or-region-wrap-region-kill 'sp-kill-region prefix))
```

and call `whole-line-or-region-sp-kill-region` (probably mapped to C-w)
to remove the whole line but only if it keeps the balance.