### PR TITLE
Fix compilation of sp--while-no-input

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -9408,44 +9408,45 @@ support custom pairs."
             (sp-show--pair-enc-function ok)))
       (execute-kbd-macro cmd))))
 
-(defalias 'sp--while-no-input 'while-no-input)
-(when (version< emacs-version "27")
-  ;; Ripped from Emacs 27.0 subr.el.
-  ;; See Github Issue#946 and Emacs bug#31692.
-  (defmacro sp--while-no-input (&rest body)
-    "Execute BODY only as long as there's no pending input.
+(eval-when-compile
+  (defalias 'sp--while-no-input 'while-no-input)
+  (when (version< emacs-version "27")
+    ;; Ripped from Emacs 27.0 subr.el.
+    ;; See Github Issue#946 and Emacs bug#31692.
+    (defmacro sp--while-no-input (&rest body)
+      "Execute BODY only as long as there's no pending input.
 If input arrives, that ends the execution of BODY,
 and `while-no-input' returns t.  Quitting makes it return nil.
 If BODY finishes, `while-no-input' returns whatever value BODY produced."
-    (declare (debug t) (indent 0))
-    (let ((catch-sym (make-symbol "input")))
-      `(with-local-quit
-         (catch ',catch-sym
-           (let ((throw-on-input ',catch-sym)
-                 val)
-             (setq val (or (input-pending-p)
-                           (progn ,@body)))
-             (cond
-              ;; When input arrives while throw-on-input is non-nil,
-              ;; kbd_buffer_store_buffered_event sets quit-flag to the
-              ;; value of throw-on-input.  If, when BODY finishes,
-              ;; quit-flag still has the same value as throw-on-input, it
-              ;; means BODY never tested quit-flag, and therefore ran to
-              ;; completion even though input did arrive before it
-              ;; finished.  In that case, we must manually simulate what
-              ;; 'throw' in process_quit_flag would do, and we must
-              ;; reset quit-flag, because leaving it set will cause us
-              ;; quit to top-level, which has undesirable consequences,
-              ;; such as discarding input etc.  We return t in that case
-              ;; because input did arrive during execution of BODY.
-              ((eq quit-flag throw-on-input)
-               (setq quit-flag nil)
-               t)
-              ;; This is for when the user actually QUITs during
-              ;; execution of BODY.
-              (quit-flag
-               nil)
-              (t val))))))))
+      (declare (debug t) (indent 0))
+      (let ((catch-sym (make-symbol "input")))
+       `(with-local-quit
+           (catch ',catch-sym
+             (let ((throw-on-input ',catch-sym)
+                   val)
+               (setq val (or (input-pending-p)
+                             (progn ,@body)))
+               (cond
+               ;; When input arrives while throw-on-input is non-nil,
+               ;; kbd_buffer_store_buffered_event sets quit-flag to the
+               ;; value of throw-on-input.  If, when BODY finishes,
+               ;; quit-flag still has the same value as throw-on-input, it
+               ;; means BODY never tested quit-flag, and therefore ran to
+               ;; completion even though input did arrive before it
+               ;; finished.  In that case, we must manually simulate what
+               ;; 'throw' in process_quit_flag would do, and we must
+               ;; reset quit-flag, because leaving it set will cause us
+               ;; quit to top-level, which has undesirable consequences,
+               ;; such as discarding input etc.  We return t in that case
+               ;; because input did arrive during execution of BODY.
+               ((eq quit-flag throw-on-input)
+                (setq quit-flag nil)
+                t)
+               ;; This is for when the user actually QUITs during
+               ;; execution of BODY.
+               (quit-flag
+                nil)
+               (t val)))))))))
 
 (defun sp-show--pair-function ()
   "Display the show pair overlays and print the line of the


### PR DESCRIPTION
This is a fix for https://github.com/Fuco1/smartparens/pull/958 when byte-compiling. The top level forms need to be wrapped in `eval-when-compile`.

See https://lists.gnu.org/archive/html/bug-gnu-emacs/2020-11/msg01056.html