### PR TITLE
Fix #707 (partly)

### DIFF
--- a/smartparens-elixir.el
+++ b/smartparens-elixir.el
@@ -30,6 +30,16 @@
 (--each '(elixir-mode)
   (add-to-list 'sp-sexp-suffix (list it 'regexp "")))
 
+(defun sp-elixir-do-keyword-p (id _action _context)
+  "Return non-nil if the \"do:\" keyword is part of definition.
+
+ID is the opening delimiter.
+
+Skips the definition if it contains \"do:\" because such syntax
+has no \"end\" delimiter."
+  (let ((line (thing-at-point 'line t)))
+    (string-match-p "\\bdo:" line)))
+
 (defun sp-elixir-def-p (id)
   "Return non-nil if the \"do\" keyword is part of definition.
 
@@ -60,7 +70,8 @@ def-do-end and similar pairs."
 (defun sp-elixir-skip-def-p (ms _mb _me)
   "Test if \"do\" is part of definition.
 MS, MB, ME."
-  (sp-elixir-def-p ms))
+  (or (sp-elixir-def-p ms)
+      (sp-elixir-do-keyword-p ms _mb _me)))
 
 (defun sp-elixir-do-block-post-handler (_id action _context)
   "Insert \"do\" keyword and indent the new block.
@@ -102,14 +113,17 @@ ID, ACTION, CONTEXT."
   (sp-local-pair "def" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
                  :post-handlers '(sp-elixir-do-block-post-handler)
+                 :skip-match 'sp-elixir-do-keyword-p
                  :unless '(sp-in-comment-p sp-in-string-p))
   (sp-local-pair "defp" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
                  :post-handlers '(sp-elixir-do-block-post-handler)
+                 :skip-match 'sp-elixir-do-keyword-p
                  :unless '(sp-in-comment-p sp-in-string-p))
   (sp-local-pair "defmodule" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
                  :post-handlers '(sp-elixir-do-block-post-handler)
+                 :skip-match 'sp-elixir-do-keyword-p
                  :unless '(sp-in-comment-p sp-in-string-p))
   (sp-local-pair "fn" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
@@ -117,10 +131,12 @@ ID, ACTION, CONTEXT."
   (sp-local-pair "if" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
                  :post-handlers '(sp-elixir-do-block-post-handler)
+                 :skip-match 'sp-elixir-do-keyword-p
                  :unless '(sp-in-comment-p sp-in-string-p))
   (sp-local-pair "unless" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
                  :post-handlers '(sp-elixir-do-block-post-handler)
+                 :skip-match 'sp-elixir-do-keyword-p
                  :unless '(sp-in-comment-p sp-in-string-p))
   (sp-local-pair "case" "end"
                  :when '(("SPC" "RET" "<evil-ret>"))
@@ -128,6 +144,7 @@ ID, ACTION, CONTEXT."
                  :unless '(sp-in-comment-p sp-in-string-p))
   (sp-local-pair "receive" "end"
                  :when '(("RET" "<evil-ret>"))
+                 :skip-match 'sp-elixir-do-keyword-p
                  :post-handlers '(sp-elixir-empty-do-block-post-handler))
   )
 


### PR DESCRIPTION
Hi, I've partly fixed #707 issue for Elixir's `do:` blocks. However there are still some problems, which are also exist in current implementation of `def ... do ... end` blocks.

With my changes the example from the linked issue no works:

``` elixir
defmodule ElixirExampleOne do
  def func_one do
    IO.puts("hi 1")
  end

  def func_two, do: IO.puts("hi 2")
end
```

`defmodule` is correctly matched with the last `end`. The `def func_two, do: IO.puts("hi 2")` is completely skipped.

However this will not work:

``` elixir
defmodule ElixirExampleOne do
  def func_one do
    IO.puts("hi 1")
  end

  def func_two, 
    do: IO.puts("hi 2")
end
```

Now, I must note, that even without my patch, the following construct will not work either:

``` elixir
defmodule ElixirExampleOne do
  def func_one
  do
    IO.puts("hi 1")
  end
end
```

This is due to the fact, that the check if line based, and we simply check if do is on the same line, which is not strict enough. I'm not sure how one would do a better check, perhaps with a search, but this does not guarantee that we'll find correct keyword, and not something that also can match.

Given that, this PR fixes specifically the `def func_two, do: IO.puts("hi 2")` case.