### PR TITLE
Add sly-mrepl-mode to sp-lisp-modes

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -579,6 +579,7 @@ Symbol is defined as a chunk of text recognized by
                            scheme-interaction-mode
                            scheme-mode
                            slime-repl-mode
+                           sly-mrepl-mode
                            stumpwm-mode
                            )
   "List of Lisp-related modes."


### PR DESCRIPTION
Similar to slime-repl-mode, sly-mrepl-mode can be added to the default
list of known lisp modes.