### PR TITLE
sp-kill-whole-line creates single kill-ring enrty

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -6804,7 +6804,9 @@ Examples:
   (let ((empty-last-line (save-excursion (beginning-of-line) (eobp))))
     ;; We can't kill the line if it is empty and the last line
     (when (and (sp-point-in-blank-line) (not empty-last-line))
-      (kill-whole-line))))
+      (append-next-kill)
+      (kill-whole-line)
+      (append-next-kill))))
 
 (defun sp--transpose-objects (first second)
   "Transpose FIRST and SECOND object while preserving the


### PR DESCRIPTION
sp-kill-whole-line now creates only on (bigger) kill-ring entry: the killed text and the killed new-line. This makes its behaviour more consistent with the built-in commands  'kill-line and 'kill-whole-line, when it comes to yanking. Also repeated invocations or combinations with other kill-commands will behave this way, which is more compliant with the emacs-conventions.