### PR TITLE
Backport ppss accessors and more

### DIFF
--- a/smartparens-pkg.el
+++ b/smartparens-pkg.el
@@ -1,3 +1,4 @@
 (define-package "smartparens" "1.11.0" "Automatic insertion, wrapping and paredit-like navigation with user defined pairs."
-  '((dash "2.13.0")
+  '((emacs "24.4")
+    (dash "2.13.0")
     (cl-lib "0.3")))

--- a/smartparens.el
+++ b/smartparens.el
@@ -82,17 +82,6 @@
 
 ;;; backport for older emacsen
 
-;; introduced in 24.3
-(unless (fboundp 'defvar-local)
-  (defmacro defvar-local (var val &optional docstring)
-    "Define VAR as a buffer-local variable with default value VAL.
-Like `defvar' but additionally marks the variable as being automatically
-buffer-local wherever it is set."
-    (declare (debug defvar) (doc-string 3))
-    ;; Can't use backquote here, it's too early in the bootstrap.
-    (list 'progn (list 'defvar var val docstring)
-          (list 'make-variable-buffer-local (list 'quote var)))))
-
 (defalias 'sp-ppss-string-terminator
   (if (version<= "27.1" emacs-version)
       'ppss-string-terminator


### PR DESCRIPTION
- Backport appropriate `ppss` accessors, they were added in Emacs 27.1.
- Remove backported `defvar-local` because smartparens already requires Emacs 24.4 and `defvar-local` was added in 24.3.
- Add emacs to the dependencies in the package file.

This PR does not introduce new failing tests.