### PR TITLE
Add support for triple quoted string literals in Scala

### DIFF
--- a/smartparens-scala.el
+++ b/smartparens-scala.el
@@ -76,5 +76,7 @@
                                 ("| " "SPC")
                                 sp-scala-wrap-with-indented-newlines))
 
+(sp-local-pair 'scala-mode "\"\"\"" "\"\"\"")
+
 (provide 'smartparens-scala)
 ;;; smartparens-scala.el ends here

--- a/test/smartparens-scala-test.el
+++ b/test/smartparens-scala-test.el
@@ -43,3 +43,10 @@
       (scala-mode)
     (execute-kbd-macro "{")
     (should (equal (buffer-string) "{\n  foo\n}"))))
+
+(ert-deftest sp-test-scala-triple-quotes ()
+  "Close triple quotes"
+  (sp-test-with-temp-buffer "sql|"
+      (scala-mode)
+    (execute-kbd-macro (kbd "\"\"\"SELECT"))
+    (should (equal (buffer-string) "sql\"\"\"SELECT\"\"\""))))


### PR DESCRIPTION
Fixes #1098

This is not very robust: inserting double quotes inside a literal doesn't seem to count towards the closing lexeme, so there's no "typing yourself out of the literal". Still, it should be better than nothing. Any pointers would be appreciated.