### PR TITLE
Scala wrap indented region correctly

### DIFF
--- a/smartparens-scala.el
+++ b/smartparens-scala.el
@@ -56,6 +56,7 @@
 (defun sp-scala-wrap-with-indented-newlines (_1 action _2)
   "Post handler for the wrap ACTION, putting the region on indented newlines."
   (when (eq action 'wrap)
+    (indent-for-tab-command)
     (sp-get sp-last-wrapped-region
       (let ((beg :beg-in)
             (end :end-in))

--- a/test/smartparens-scala-test.el
+++ b/test/smartparens-scala-test.el
@@ -44,6 +44,13 @@
     (execute-kbd-macro "{")
     (should (equal (buffer-string) "{\n  foo\n}"))))
 
+(ert-deftest sp-test-scala-curly-wrap-indent ()
+  "Wrap an indented region in an indented block"
+  (sp-test-with-temp-buffer "if (true)\n  |fooM"
+      (scala-mode)
+    (execute-kbd-macro "{")
+    (should (equal (buffer-string) "if (true)\n{\n  foo\n}"))))
+
 (ert-deftest sp-test-scala-triple-quotes ()
   "Close triple quotes"
   (sp-test-with-temp-buffer "sql|"


### PR DESCRIPTION
Hello, 

thanks for awesome package, here is a fix for wrapping region with `{` in scala.

Without this fix result of `sp-test-scala-curly-wrap-indent` test would be: 
```
"if (true)\n{fo\n  o\n}"
```
Instead of correct
```
"if (true)\n{\n foo\n}"
```