### PR TITLE
Add more pairs for OCaml

### DIFF
--- a/smartparens-ml.el
+++ b/smartparens-ml.el
@@ -60,6 +60,9 @@
   (sp-local-pair "`" nil :actions nil)
   ;; Disable ' because it is used in value names and types
   (sp-local-pair "'" nil :actions nil)
+  (sp-local-pair "{|" "|}" )
+  (sp-local-pair "sig" "end" )
+  (sp-local-pair "module" "end" )
   (sp-local-pair "(*" "*)" ))
 
 ;; Ignore punctuation, so we can split ~(foo) to ~foo.

--- a/smartparens-ml.el
+++ b/smartparens-ml.el
@@ -60,10 +60,10 @@
   (sp-local-pair "`" nil :actions nil)
   ;; Disable ' because it is used in value names and types
   (sp-local-pair "'" nil :actions nil)
-  (sp-local-pair "{|" "|}" )
-  (sp-local-pair "sig" "end" )
-  (sp-local-pair "module" "end" )
-  (sp-local-pair "(*" "*)" ))
+  (sp-local-pair "{|" "|}" )      ;; multi-line string
+  (sp-local-pair "sig" "end" )    ;; signature
+  (sp-local-pair "module" "end" ) ;; module
+  (sp-local-pair "(*" "*)" ))     ;; comment
 
 ;; Ignore punctuation, so we can split ~(foo) to ~foo.
 (add-to-list 'sp-sexp-prefix (list 'tuareg-mode 'syntax ""))

--- a/smartparens-ml.el
+++ b/smartparens-ml.el
@@ -61,6 +61,7 @@
   ;; Disable ' because it is used in value names and types
   (sp-local-pair "'" nil :actions nil)
   (sp-local-pair "{|" "|}" )      ;; multi-line string
+  (sp-local-pair "[|" "|]" )      ;; array
   (sp-local-pair "sig" "end" )    ;; signature
   (sp-local-pair "module" "end" ) ;; module
   (sp-local-pair "(*" "*)" ))     ;; comment


### PR DESCRIPTION
Thanks for the great package!
This adds more smart pairs for OCaml languages:

```ocaml
module ... end  (* module *)
sig .... end  (* signature *)
{| ... |}  (* multi-line string *)
[| ... |] (* array *)
```