### PR TITLE
Fix `module...end` to `struct..end` for OCaml

### DIFF
--- a/smartparens-ml.el
+++ b/smartparens-ml.el
@@ -63,7 +63,7 @@
   (sp-local-pair "{|" "|}" )      ;; multi-line string
   (sp-local-pair "[|" "|]" )      ;; array
   (sp-local-pair "sig" "end" )    ;; signature
-  (sp-local-pair "module" "end" ) ;; module
+  (sp-local-pair "struct" "end" ) ;; module
   (sp-local-pair "(*" "*)" ))     ;; comment
 
 ;; Ignore punctuation, so we can split ~(foo) to ~foo.


### PR DESCRIPTION
Thanks for the great package.
I added some pairs for OCaml in #1118, but I found my mistake. This fixes `module ... end` to `struct ... end`.
Thank you!