### PR TITLE
Add pairs for doxygen formulas in C / C++

### DIFF
--- a/smartparens-c.el
+++ b/smartparens-c.el
@@ -48,5 +48,10 @@
   (sp-local-pair "/*" "*/" :post-handlers '(("| " "SPC")
                                             ("* ||\n[i]" "RET"))))
 
+;; inline formulas for doxygen
+(sp-with-modes sp-c-modes
+  (sp-local-pair "\\f[" "\\f]" :when '(sp-in-comment-p))
+  (sp-local-pair "\\f$" "\\f$" :when '(sp-in-comment-p)))
+
 (provide 'smartparens-c)
 ;;; smartparens-c.el ends here


### PR DESCRIPTION
There is a little-known [feature](https://www.doxygen.nl/manual/formulas.html) inside doxygen, which allows users to add inline formulas to the documentation:

```c
  // The distance between \f$(x_1,y_1)\f$ and \f$(x_2,y_2)\f$ is 
  // \f$\sqrt{(x_2-x_1)^2+(y_2-y_1)^2}\f$.
```

This patch adds the corresponding pairs to the `sp-c-modes`.