### PR TITLE
Latex fixes

### DIFF
--- a/smartparens-latex.el
+++ b/smartparens-latex.el
@@ -179,13 +179,7 @@ ID, ACTION, CONTEXT."
   (sp-local-pair  "\\lvert" "\\rvert"
           :when '(sp-in-math-p)
           :trigger "\\lvert"
-          :post-handlers '(sp-latex-insert-spaces-inside-pair))
-
-  ;; some common wrappings
-  (sp-local-tag "\"" "``" "''" :actions '(wrap))
-  (sp-local-tag "\\b" "\\begin{_}" "\\end{_}")
-  (sp-local-tag "bi" "\\begin{itemize}" "\\end{itemize}")
-  (sp-local-tag "be" "\\begin{enumerate}" "\\end{enumerate}"))
+          :post-handlers '(sp-latex-insert-spaces-inside-pair)))
 
 (provide 'smartparens-latex)
 

--- a/smartparens-latex.el
+++ b/smartparens-latex.el
@@ -77,25 +77,27 @@ ID, ACTION, CONTEXT."
   ;; Disable pairs that interfere with AucTeX.
   (sp-local-pair "`" nil :actions nil)
   (sp-local-pair "\"" nil :actions nil)
+
+  ;; Math modes, yay.  The :actions are provided automatically if
   ;; these pairs do not have global definitions.
   (sp-local-pair "$" "$")
   (sp-local-pair "\\[" "\\]"
                  :unless '(sp-latex-point-after-backslash))
 
-  ;; disable useless pairs.
+  ;; Disable useless pairs.
   (sp-local-pair "\\\\(" nil :actions nil)
   (sp-local-pair "'" nil :actions nil)
   (sp-local-pair "\\\"" nil :actions nil)
 
-  ;; add the prefix function sticking to {} pair
+  ;; Add the prefix function sticking to {} pair.
   (sp-local-pair "{" nil :prefix "\\\\\\(\\sw\\|\\s_\\)*")
 
-  ;; do not add more space when slurping
+  ;; Do not add more space when slurping.
   (sp-local-pair "{" "}")
   (sp-local-pair "(" ")")
   (sp-local-pair "[" "]")
 
-  ;; pairs for big brackets.  Needs more research on what pairs are
+  ;; Pairs for big brackets.  Needs more research on what pairs are
   ;; useful to add here.  Post suggestions if you know some.
   (sp-local-pair "\\left(" "\\right)"
                  :trigger "\\l("

--- a/smartparens-latex.el
+++ b/smartparens-latex.el
@@ -62,21 +62,6 @@
       (goto-char (sp-get sp-last-wrapped-region :beg-in))
       (insert " "))))
 
-(defun sp-latex-skip-match-apostrophe (ms _mb me)
-  "MS, MB, ME."
-  (when (equal ms "'")
-    (save-excursion
-      (goto-char me)
-      (looking-at-p "\\sw"))))
-
-(defun sp-latex-skip-double-quote (_id action _context)
-  "ID, ACTION, CONTEXT."
-  (when (eq action 'insert)
-    (when (looking-at-p "''''")
-      (delete-char -2)
-      (delete-char 2)
-      (forward-char 2))))
-
 (defun sp-latex-point-after-backslash (id action _context)
   "Return t if point follows a backslash, nil otherwise.
 This predicate is only tested on \"insert\" action.
@@ -89,11 +74,9 @@ ID, ACTION, CONTEXT."
              '((tex-mode plain-tex-mode latex-mode) . sp--backslash-skip-match))
 
 (sp-with-modes '(tex-mode plain-tex-mode latex-mode LaTeX-mode)
-  (sp-local-pair "`" "'"
-                 :actions '(:rem autoskip)
-                 :skip-match 'sp-latex-skip-match-apostrophe
-                 :unless '(sp-latex-point-after-backslash sp-in-math-p))
-  ;; math modes, yay.  The :actions are provided automatically if
+  ;; Disable pairs that interfere with AucTeX.
+  (sp-local-pair "`" nil :actions nil)
+  (sp-local-pair "\"" nil :actions nil)
   ;; these pairs do not have global definitions.
   (sp-local-pair "$" "$")
   (sp-local-pair "\\[" "\\]"
@@ -103,13 +86,6 @@ ID, ACTION, CONTEXT."
   (sp-local-pair "\\\\(" nil :actions nil)
   (sp-local-pair "'" nil :actions nil)
   (sp-local-pair "\\\"" nil :actions nil)
-
-  ;; quote should insert ``'' instead of double quotes.  If we ever
-  ;; need to insert ", C-q is our friend.
-  (sp-local-pair "``" "''"
-                 :trigger "\""
-                 :unless '(sp-latex-point-after-backslash sp-in-math-p)
-                 :post-handlers '(sp-latex-skip-double-quote))
 
   ;; add the prefix function sticking to {} pair
   (sp-local-pair "{" nil :prefix "\\\\\\(\\sw\\|\\s_\\)*")

--- a/smartparens-latex.el
+++ b/smartparens-latex.el
@@ -88,12 +88,7 @@ ID, ACTION, CONTEXT."
 (add-to-list 'sp-navigate-skip-match
              '((tex-mode plain-tex-mode latex-mode) . sp--backslash-skip-match))
 
-(sp-with-modes '(
-                 tex-mode
-                 plain-tex-mode
-                 latex-mode
-                 LaTeX-mode
-                 )
+(sp-with-modes '(tex-mode plain-tex-mode latex-mode LaTeX-mode)
   (sp-local-pair "`" "'"
                  :actions '(:rem autoskip)
                  :skip-match 'sp-latex-skip-match-apostrophe


### PR DESCRIPTION
Hi! This fixes https://github.com/Fuco1/smartparens/issues/1100; well, it disables some features of `smartparens` for latex modes. The PR also includes some other nits and changes. Let me know if I should exclude those.

Finally, this change is a breaking change for people using
```emacs-lisp
(sp-local-pair modes "``" nil ...))) ;; or
(sp-local-pair modes "`" nil ...)))
```

For example, this affects Doom Emacs, which I am using. The corresponding patch for Doom Emacs is attached.
[s.patch](https://github.com/Fuco1/smartparens/files/10995599/s.patch)
