### PR TITLE
Prevent paired $ in latex after \$

### DIFF
--- a/smartparens-latex.el
+++ b/smartparens-latex.el
@@ -100,7 +100,8 @@ ID, ACTION, CONTEXT."
                  :unless '(sp-latex-point-after-backslash sp-in-math-p))
   ;; math modes, yay.  The :actions are provided automatically if
   ;; these pairs do not have global definitions.
-  (sp-local-pair "$" "$")
+  (sp-local-pair "$" "$"
+                 :unless '(sp-latex-point-after-backslash))
   (sp-local-pair "\\[" "\\]"
                  :unless '(sp-latex-point-after-backslash))
 


### PR DESCRIPTION
I think this is self-explanatory, but you need to escape $ to get a literal dollar sign and we don't want the pair in this case (for math mode). 