### PR TITLE
`kill-ring` should not be `let-bind`ed to `kill-ring`itself on `sp(-backward)?-delete-symbol`

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -9085,7 +9085,7 @@ backward direction.
 
 See `sp-forward-symbol' for what constitutes a symbol."
   (interactive "*p")
-  (let* ((kill-ring kill-ring)
+  (let* ((kill-ring nil)
          (select-enable-clipboard nil))
     (sp-kill-symbol arg word)))
 
@@ -9162,7 +9162,7 @@ forward direction.
 
 See `sp-backward-symbol' for what constitutes a symbol."
   (interactive "*p")
-  (let* ((kill-ring kill-ring)
+  (let* ((kill-ring nil)
          (select-enable-clipboard nil))
     (sp-backward-kill-symbol arg word)))
 


### PR DESCRIPTION
Hi, I fixed the bug that `sp-delete-symbol` and `sp-backward-delete-symbol` destruct `kill-ring`.
Here is reproduction process:
```emacs-lisp
(setq kill-ring '("kill-ring-value"))
; => ("kill-ring-value")
abc def ; At the beginning of this line, run `sp-delete-symbol' twice
kill-ring
; => (#("kill-ring-valuedef" 15 18 (fontified t)))
```

# Explanation
Wrapping with `(let ((kill-ring kill-ring) (select-enable-clipboard nil)) ...)` is no mean, because the `kill-*` commands destructively edit the list which globally binds `kill-ring`, even with `let-bind`.

`kill-ring` is just a list. When list is passed to other variable, it is NOT copied but passed as reference. So the `let-bind`ing `kill-ring` to `kill-ring` does nothing, and destructive editing  is not reverted. If we want to copy the list, you need to use `purecopy`.

Therefore, we can fix this bug by `let-bind`ing `kill-ring` to other list, like `nil`.

