### PR TITLE
fix: don't indent after kill in python-ts-mode

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -613,6 +613,7 @@ Symbol is defined as a chunk of text recognized by
 
 (defcustom sp-no-reindent-after-kill-modes '(
                                              python-mode
+                                             python-ts-mode
                                              coffee-mode
                                              asm-mode
                                              makefile-gmake-mode


### PR DESCRIPTION
Emacs 29 introduced treesitter programming modes. This updates the list of modes where a reindent shouldn't be performed after kill to take that into account.