### PR TITLE
Add support for js-ts-mode and typescript-ts-mode

### DIFF
--- a/smartparens-config.el
+++ b/smartparens-config.el
@@ -148,7 +148,7 @@ ID, ACTION, CONTEXT."
 (eval-after-load 'tuareg                   '(require 'smartparens-ml))
 (eval-after-load 'fsharp-mode              '(require 'smartparens-ml))
 (eval-after-load 'unisonlang-mode          '(require 'smartparens-unison))
-(--each '(js js2-mode)
+(--each '(js js2-mode typescript-ts-mode)
   (eval-after-load it                      '(require 'smartparens-javascript)))
 (provide 'smartparens-config)
 

--- a/smartparens-javascript.el
+++ b/smartparens-javascript.el
@@ -48,7 +48,16 @@
 
 ;; (|sys).path.append---the dot should not travel with the closing
 ;; paren
-(--each '(js-mode javascript-mode js2-mode typescript-mode rjsx-mode)
+(--each '(
+          js-mode
+          javascript-mode
+          js2-mode
+          typescript-mode
+          rjsx-mode
+          js-ts-mode
+          typescript-ts-mode
+          tsx-ts-mode
+          )
   (add-to-list 'sp-sexp-suffix (list it 'regexp "")))
 
 (provide 'smartparens-javascript)

--- a/smartparens.el
+++ b/smartparens.el
@@ -642,6 +642,7 @@ Symbol is defined as a chunk of text recognized by
                          js-jsx-mode
                          js2-jsx-mode
                          rjsx-mode
+                         tsx-ts-mode
                          )
   "List of HTML modes.")
 


### PR DESCRIPTION
Adds the new Emacs 29+ `js-ts-mode` and `typescript/tsx-ts-mode` to the configs for `smartparent-javascript`. 

I also added `tsx-ts-mode` to `sp--html-modes` which  should address https://github.com/Fuco1/smartparens/issues/1168.