### PR TITLE
Add support for clojure-ts-mode

### DIFF
--- a/smartparens-clojure.el
+++ b/smartparens-clojure.el
@@ -44,8 +44,7 @@
 (defvar sp-clojure-prefix "\\(?:[@`'#~,_?^]+\\)"
   "Prefix used in `sp-sexp-prefix' for clojure modes.")
 
-(dolist (mode '(clojure-mode clojurescript-mode clojurec-mode cider-repl-mode
-                clojure-ts-mode clojurescript-ts-mode clojurec-ts-mode))
+(dolist (mode '(clojure-mode cider-repl-mode clojure-ts-mode))
   (add-to-list 'sp-sexp-prefix `(,mode regexp ,sp-clojure-prefix)))
 
 ;; Match "`" with "`" in strings and comments

--- a/smartparens-clojure.el
+++ b/smartparens-clojure.el
@@ -44,7 +44,8 @@
 (defvar sp-clojure-prefix "\\(?:[@`'#~,_?^]+\\)"
   "Prefix used in `sp-sexp-prefix' for clojure modes.")
 
-(dolist (mode '(clojure-mode clojurescript-mode clojurec-mode cider-repl-mode))
+(dolist (mode '(clojure-mode clojurescript-mode clojurec-mode cider-repl-mode
+                clojure-ts-mode clojurescript-ts-mode clojurec-ts-mode))
   (add-to-list 'sp-sexp-prefix `(,mode regexp ,sp-clojure-prefix)))
 
 ;; Match "`" with "`" in strings and comments

--- a/smartparens-clojure.el
+++ b/smartparens-clojure.el
@@ -44,7 +44,8 @@
 (defvar sp-clojure-prefix "\\(?:[@`'#~,_?^]+\\)"
   "Prefix used in `sp-sexp-prefix' for clojure modes.")
 
-(dolist (mode '(clojure-mode cider-repl-mode clojure-ts-mode))
+(dolist (mode '(clojure-mode clojurescript-mode clojurec-mode cider-repl-mode
+                clojure-ts-mode clojurescript-ts-mode clojurec-ts-mode))
   (add-to-list 'sp-sexp-prefix `(,mode regexp ,sp-clojure-prefix)))
 
 ;; Match "`" with "`" in strings and comments

--- a/smartparens-config.el
+++ b/smartparens-config.el
@@ -117,7 +117,8 @@ ID, ACTION, CONTEXT."
 ;; macro, you MUST supply the major mode argument.
 
 (eval-after-load 'cc-mode                  '(require 'smartparens-c))
-(eval-after-load 'clojure-mode             '(require 'smartparens-clojure))
+(--each '(clojure-mode clojure-ts-mode)
+  (eval-after-load it                      '(require 'smartparens-clojure)))
 (eval-after-load 'crystal-mode             '(require 'smartparens-crystal))
 (eval-after-load 'elixir-mode              '(require 'smartparens-elixir))
 (eval-after-load 'elixir-ts-mode           '(require 'smartparens-elixir))

--- a/smartparens.el
+++ b/smartparens.el
@@ -562,12 +562,7 @@ Symbol is defined as a chunk of text recognized by
 (defcustom sp-lisp-modes '(
                            cider-repl-mode
                            clojure-mode
-                           clojurec-mode
-                           clojurescript-mode
-                           clojurex-mode
                            clojure-ts-mode
-                           clojurescript-ts-mode
-                           clojurec-ts-mode
                            common-lisp-mode
                            emacs-lisp-mode
                            eshell-mode
@@ -597,12 +592,7 @@ Symbol is defined as a chunk of text recognized by
 (defcustom sp-clojure-modes '(
                               cider-repl-mode
                               clojure-mode
-                              clojurec-mode
-                              clojurescript-mode
-                              clojurex-mode
                               clojure-ts-mode
-                              clojurescript-ts-mode
-                              clojurec-ts-mode
                               inf-clojure-mode
                               )
   "List of Clojure-related modes."

--- a/smartparens.el
+++ b/smartparens.el
@@ -562,7 +562,12 @@ Symbol is defined as a chunk of text recognized by
 (defcustom sp-lisp-modes '(
                            cider-repl-mode
                            clojure-mode
+                           clojurec-mode
+                           clojurescript-mode
+                           clojurex-mode
                            clojure-ts-mode
+                           clojurescript-ts-mode
+                           clojurec-ts-mode
                            common-lisp-mode
                            emacs-lisp-mode
                            eshell-mode
@@ -592,7 +597,12 @@ Symbol is defined as a chunk of text recognized by
 (defcustom sp-clojure-modes '(
                               cider-repl-mode
                               clojure-mode
+                              clojurec-mode
+                              clojurescript-mode
+                              clojurex-mode
                               clojure-ts-mode
+                              clojurescript-ts-mode
+                              clojurec-ts-mode
                               inf-clojure-mode
                               )
   "List of Clojure-related modes."

--- a/smartparens.el
+++ b/smartparens.el
@@ -565,6 +565,9 @@ Symbol is defined as a chunk of text recognized by
                            clojurec-mode
                            clojurescript-mode
                            clojurex-mode
+                           clojure-ts-mode
+                           clojurescript-ts-mode
+                           clojurec-ts-mode
                            common-lisp-mode
                            emacs-lisp-mode
                            eshell-mode
@@ -597,6 +600,9 @@ Symbol is defined as a chunk of text recognized by
                               clojurec-mode
                               clojurescript-mode
                               clojurex-mode
+                              clojure-ts-mode
+                              clojurescript-ts-mode
+                              clojurec-ts-mode
                               inf-clojure-mode
                               )
   "List of Clojure-related modes."


### PR DESCRIPTION
[`clojure-ts-mode`](https://github.com/clojure-emacs/clojure-ts-mode)  is developed as a distinct alternative to `clojure-mode`, as discussed here: https://github.com/clojure-emacs/clojure-mode/issues/640#issuecomment-1359708131