### PR TITLE
Fix invalid alias definition for `syntax-class-to-char'

### DIFF
--- a/smartparens.el
+++ b/smartparens.el
@@ -1858,12 +1858,13 @@ P is the point at which we run `syntax-ppss'"
             (list p (point-min) (point-max))
             (sp-state-last-syntax-ppss-result sp-state) (syntax-ppss p)))))
 
-(eval-when-compile
-  (defalias 'sp--syntax-class-to-char 'syntax-class-to-char)
-  (when (version< emacs-version "28.1")
+;; `syntax-class-to-char' is new in Emacs 28.1.
+(defalias 'sp--syntax-class-to-char
+  (if (fboundp 'syntax-class-to-char)
+      #'syntax-class-to-char
     ;; Ripped from Emacs 27.0 subr.el.
     ;; See Github Issue#946 and Emacs bug#31692.
-    (defun sp--syntax-class-to-char (syntax)
+    (lambda (syntax)
       "Return the syntax char of CLASS, described by an integer.
 For example, if SYNTAX is word constituent (the integer 2), the
 character ‘w’ (119) is returned.


### PR DESCRIPTION
`eval-when-compile' defines the alias symbol only at compile time and not when the program is loaded and thus results in a void error at runtime.

Fixes #1204