### PR TITLE
 `RET` create a newline inside empty pairs 

### DIFF
--- a/smartparens-rust.el
+++ b/smartparens-rust.el
@@ -133,6 +133,10 @@ ARGS."
                  :when '(sp-rust-filter-angle-brackets)
                  :skip-match 'sp-rust-skip-match-angle-bracket))
 
+  (dolist (open '("<" "{" "[" "("))
+    (sp-local-pair '(rust-mode rust-ts-mode rustic-mode)
+                   open nil :post-handlers '(:add ("||\n[i]" "RET"))))
+
 ;; Rust has no sexp suffices.  This fixes slurping
 ;; (|foo).bar -> (foo.bar)
 (add-to-list 'sp-sexp-suffix (list #'rust-mode 'regexp ""))


### PR DESCRIPTION
Rust prefers block indent style ([style guide](https://doc.rust-lang.org/stable/style-guide/index.html#block-indent)) so inserting a newline should be the default behavior.