### PR TITLE
config for c-ts-mode and c++-ts-mode

### DIFF
--- a/smartparens-config.el
+++ b/smartparens-config.el
@@ -128,7 +128,8 @@ ID, ACTION, CONTEXT."
 ;; automatically.  If you want to call sp-local-pair outside this
 ;; macro, you MUST supply the major mode argument.
 
-(eval-after-load 'cc-mode                  '(require 'smartparens-c))
+(--each '(cc-mode c-ts-mode)
+  (eval-after-load it                      '(require 'smartparens-c)))
 (--each '(clojure-mode clojure-ts-mode)
   (eval-after-load it                      '(require 'smartparens-clojure)))
 (eval-after-load 'coq-mode                 '(require 'smartparens-coq))

--- a/smartparens.el
+++ b/smartparens.el
@@ -612,6 +612,8 @@ Symbol is defined as a chunk of text recognized by
 (defcustom sp-c-modes '(
                         c-mode
                         c++-mode
+                        c-ts-mode
+                        c++-ts-mode
                         )
   "List of C-related modes."
   :type '(repeat symbol)


### PR DESCRIPTION
Require `smartparens-c` when `c-ts-mode` is loaded, and add `c-ts-mode` and `c++-ts-mode` to `sp-c-modes`.