### PR TITLE
Copy dependencies into smartparens.el for MELPA

### DIFF
--- a/smartparens-pkg.el
+++ b/smartparens-pkg.el
@@ -1,3 +1,2 @@
 (define-package "smartparens" "1.11.0" "Automatic insertion, wrapping and paredit-like navigation with user defined pairs."
-  '((dash "2.13.0")
-    (cl-lib "0.3")))
+  '((dash "2.13.0")))

--- a/smartparens.el
+++ b/smartparens.el
@@ -6,6 +6,7 @@
 ;; Maintainer: Matus Goljer <matus.goljer@gmail.com>
 ;; Created: 17 Nov 2012
 ;; Version: 1.11.0
+;; Package-Requires: ((dash "2.13.0"))
 ;; Keywords: abbrev convenience editing
 ;; URL: https://github.com/Fuco1/smartparens
 


### PR DESCRIPTION
MELPA recently stopped extracting dependencies from smartparens-pkg.el (see
https://github.com/melpa/package-build/commit/760cf53114a6f27e86bc87b44726ced34bcda0ea). In a fresh install (using `emacs --init-directory` pointed at a directory with just an init.el configuring MELPA, no other packages installed), `M-x package-install smartparens` does not install dash, which means smartparens does not work.

Try to fix it by copying the dependencies from smartparens-pkg.el to a Package-Requires header, which MELPA should still extract.

Drop the dependency on cl-lib while I'm there. This was needed in Emacs < 24, which smartparens no longer supports.