### PR TITLE
Don't pair escaped parens in swift-mode

### DIFF
--- a/smartparens-swift.el
+++ b/smartparens-swift.el
@@ -106,7 +106,8 @@
   (sp-local-pair "<" ">"
                  :when '(sp-swift-filter-angle-brackets)
                  :skip-match 'sp-swift-skip-match-angle-bracket)
-  (sp-local-pair "\"\"\"" "\"\"\""))
+  (sp-local-pair "\"\"\"" "\"\"\"")
+  (sp-local-pair "\\(" nil :actions nil))
 
 ;; Swift has no sexp suffices.  This fixes slurping
 ;; (|foo).bar -> (foo.bar)

--- a/test/smartparens-swift-test.el
+++ b/test/smartparens-swift-test.el
@@ -123,3 +123,10 @@ func bar(x: UInt64) -> Bool {
     (mark-whole-buffer)
     (call-interactively 'sp-kill-region)
     (should (equal (buffer-string) ""))))
+
+(ert-deftest sp-test-swift-string-interp-paren ()
+  "String interpolation should not escape closing paren"
+  (sp-test-with-temp-buffer "print(\"foo is: |\")"
+      (swift-mode)
+    (execute-kbd-macro "\\(")
+    (sp-buffer-equals "print(\"foo is: \\(|)\")")))


### PR DESCRIPTION
Related to #1225 

This disables pairing escaped parens together, but still allows a "\(" to be paired and become "\()" which is commonly used for string interpolation. 