### PR TITLE
feat(purescript): add support for purescript-mode

### DIFF
--- a/smartparens-config.el
+++ b/smartparens-config.el
@@ -141,8 +141,8 @@ ID, ACTION, CONTEXT."
   (eval-after-load it                      '(require 'smartparens-erlang)))
 (eval-after-load 'ess                      '(require 'smartparens-ess))
 (eval-after-load 'go-mode                  '(require 'smartparens-go))
-(eval-after-load 'haskell-interactive-mode '(require 'smartparens-haskell))
-(eval-after-load 'haskell-mode             '(require 'smartparens-haskell))
+(--each '(haskell-mode haskell-interactive-mode purescript-mode)
+  (eval-after-load it                      '(require 'smartparens-haskell)))
 (--each sp--html-modes
   (eval-after-load it                      '(require 'smartparens-html)))
 (eval-after-load 'latex                    '(require 'smartparens-latex))

--- a/smartparens-haskell.el
+++ b/smartparens-haskell.el
@@ -78,6 +78,14 @@ So we ignore that pair when at the end of word."
                  :skip-match 'sp-haskell-skip-apostrophe)
   (sp-local-pair "\\(" nil :actions nil))
 
+(sp-with-modes 'purescript-mode
+  (sp-local-pair "'" nil
+                 :unless '(sp-point-after-word-p
+                           sp-haskell-strict-ignore-apostrophe-after-word)
+                 :skip-match 'sp-haskell-skip-apostrophe)
+  (sp-local-pair "\\{" nil :actions nil)
+  (sp-local-pair "\\(" nil :actions nil))
+
 (defun sp--inferior-haskell-mode-backward-bound-fn ()
   "Limit the backward search to the prompt if point is on prompt."
   (-when-let (limit (cond ((bound-and-true-p comint-last-prompt)

--- a/smartparens.el
+++ b/smartparens.el
@@ -623,6 +623,7 @@ Symbol is defined as a chunk of text recognized by
 (defcustom sp-no-reindent-after-kill-modes '(
                                              python-mode
                                              python-ts-mode
+                                             purescript-mode
                                              coffee-mode
                                              asm-mode
                                              makefile-gmake-mode


### PR DESCRIPTION
`purescript-mode` started as a fork of `haskell-mode` and in general, PureScript looks and behaves like Haskell. This PR adds basic support for PureScript (and should fix https://github.com/Fuco1/smartparens/issues/1236).